### PR TITLE
feat: replace gutenberg edit screen with classic metaboxes

### DIFF
--- a/src/Admin/BookmarkMetabox.php
+++ b/src/Admin/BookmarkMetabox.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\LinkStash\Admin;
+
+\defined( 'ABSPATH' ) || exit();
+
+use Apermo\LinkStash\PostType\BookmarkMeta;
+use Apermo\LinkStash\PostType\BookmarkPostType;
+use Apermo\LinkStash\Url\Canonicalizer;
+use Apermo\LinkStash\Url\DisplayUrl;
+use WP_Post;
+
+/**
+ * Replaces the default bookmark edit screen with a small classic-editor form.
+ *
+ * Registers two meta boxes — a URL panel (URL + unread + archived flags)
+ * and a Notes panel (plain textarea bound to post_content) — and disables
+ * the block editor for the bookmark CPT so the classic edit screen is
+ * used instead. Saving falls back to a simplified URL as the post_title
+ * when the user does not supply an explicit label.
+ */
+class BookmarkMetabox {
+
+	private const NONCE_FIELD  = 'linkstash_metabox_nonce';
+	private const NONCE_ACTION = 'linkstash_save_metabox';
+
+	/**
+	 * Returns true when this save_post invocation should persist meta-box state.
+	 *
+	 * Bails on autosaves, revisions, missing nonces, and capability misses.
+	 *
+	 * @param int $post_id Post ID being saved.
+	 *
+	 * @return bool
+	 */
+	private static function should_persist( int $post_id ): bool {
+		if ( \defined( 'DOING_AUTOSAVE' ) && \DOING_AUTOSAVE ) {
+			return false;
+		}
+		if ( wp_is_post_revision( $post_id ) ) {
+			return false;
+		}
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return false;
+		}
+		if ( ! isset( $_POST[ self::NONCE_FIELD ] ) || ! \is_string( $_POST[ self::NONCE_FIELD ] ) ) {
+			return false;
+		}
+
+		$nonce = sanitize_text_field( wp_unslash( $_POST[ self::NONCE_FIELD ] ) );
+
+		return (bool) wp_verify_nonce( $nonce, self::NONCE_ACTION );
+	}
+
+	/**
+	 * Reads a text field from the POST request, sanitised and unslashed.
+	 *
+	 * @param string $key Field name.
+	 *
+	 * @return string
+	 */
+	private static function read_text( string $key ): string {
+		// Nonce verification happens in self::should_persist before save_post
+		// reaches this helper.
+		// phpcs:disable WordPress.Security.NonceVerification.Missing
+		if ( ! isset( $_POST[ $key ] ) || ! \is_string( $_POST[ $key ] ) ) {
+			return '';
+		}
+
+		return sanitize_text_field( wp_unslash( $_POST[ $key ] ) );
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+	}
+
+	/**
+	 * Updates the given post fields without re-triggering save_post handlers.
+	 *
+	 * Detaches our own save_post hook for the duration of the update so the
+	 * fallback-title write does not cause an infinite loop.
+	 *
+	 * @param int                  $post_id Post ID.
+	 * @param array<string, mixed> $fields  Fields to update.
+	 *
+	 * @return void
+	 */
+	private static function update_post_fields( int $post_id, array $fields ): void {
+		$instance = null;
+		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		global $wp_filter;
+		$hook_name = 'save_post_' . BookmarkPostType::POST_TYPE;
+		if ( isset( $wp_filter[ $hook_name ] ) ) {
+			foreach ( $wp_filter[ $hook_name ]->callbacks as $callbacks ) {
+				foreach ( $callbacks as $entry ) {
+					$callback = $entry['function'] ?? null;
+					if ( \is_array( $callback ) && $callback[0] instanceof self ) {
+						$instance = $callback[0];
+						break 2;
+					}
+				}
+			}
+		}
+		// phpcs:enable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+		if ( $instance !== null ) {
+			remove_action( $hook_name, [ $instance, 'save_post' ], 10 );
+		}
+
+		wp_update_post( \array_merge( [ 'ID' => $post_id ], $fields ) );
+
+		if ( $instance !== null ) {
+			add_action( $hook_name, [ $instance, 'save_post' ], 10, 2 );
+		}
+	}
+
+	/**
+	 * Hooks the meta-box registration, save handler, and editor filter.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_action( 'add_meta_boxes_' . BookmarkPostType::POST_TYPE, [ $this, 'register_meta_boxes' ] );
+		add_action( 'save_post_' . BookmarkPostType::POST_TYPE, [ $this, 'save_post' ], 10, 2 );
+		add_filter( 'use_block_editor_for_post_type', [ $this, 'disable_block_editor' ], 10, 2 );
+	}
+
+	/**
+	 * Returns false for the bookmark CPT so the classic editor is used.
+	 *
+	 * @param bool   $use_block_editor Whether to use the block editor.
+	 * @param string $post_type        Post-type slug.
+	 *
+	 * @return bool
+	 */
+	public function disable_block_editor( bool $use_block_editor, string $post_type ): bool {
+		if ( $post_type === BookmarkPostType::POST_TYPE ) {
+			return false;
+		}
+
+		return $use_block_editor;
+	}
+
+	/**
+	 * Registers the URL and Notes meta boxes for the bookmark CPT.
+	 *
+	 * @return void
+	 */
+	public function register_meta_boxes(): void {
+		add_meta_box(
+			'linkstash_bookmark_url',
+			__( 'Bookmark URL', 'linkstash' ),
+			[ $this, 'render_url_meta_box' ],
+			BookmarkPostType::POST_TYPE,
+			'side',
+			'high',
+		);
+
+		add_meta_box(
+			'linkstash_bookmark_note',
+			__( 'Notes', 'linkstash' ),
+			[ $this, 'render_note_meta_box' ],
+			BookmarkPostType::POST_TYPE,
+			'normal',
+			'default',
+		);
+	}
+
+	/**
+	 * Renders the URL meta box with URL, unread, and archived inputs.
+	 *
+	 * @param WP_Post $post Current post.
+	 *
+	 * @return void
+	 */
+	public function render_url_meta_box( WP_Post $post ): void {
+		$url      = (string) get_post_meta( $post->ID, BookmarkMeta::META_URL, true );
+		$unread   = (bool) get_post_meta( $post->ID, BookmarkMeta::META_UNREAD, true );
+		$archived = (bool) get_post_meta( $post->ID, BookmarkMeta::META_ARCHIVED, true );
+		wp_nonce_field( self::NONCE_ACTION, self::NONCE_FIELD );
+		?>
+		<p>
+			<label for="linkstash-url"><strong><?php esc_html_e( 'URL', 'linkstash' ); ?></strong></label><br />
+			<input type="url"
+					id="linkstash-url"
+					name="linkstash_url"
+					value="<?php echo esc_attr( $url ); ?>"
+					required
+					class="widefat"
+					placeholder="https://&hellip;" />
+		</p>
+		<p>
+			<label>
+				<input type="checkbox" name="linkstash_unread" value="1" <?php checked( $unread ); ?> />
+				<?php esc_html_e( 'Unread', 'linkstash' ); ?>
+			</label>
+		</p>
+		<p>
+			<label>
+				<input type="checkbox" name="linkstash_archived" value="1" <?php checked( $archived ); ?> />
+				<?php esc_html_e( 'Archived', 'linkstash' ); ?>
+			</label>
+		</p>
+		<p class="description">
+			<?php esc_html_e( 'Leave the title field empty to use the URL as the title.', 'linkstash' ); ?>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Renders the Notes meta box (plain textarea bound to post_content).
+	 *
+	 * @param WP_Post $post Current post.
+	 *
+	 * @return void
+	 */
+	public function render_note_meta_box( WP_Post $post ): void {
+		?>
+		<textarea name="linkstash_note"
+					id="linkstash-note"
+					class="widefat"
+					rows="8"
+					placeholder="<?php esc_attr_e( 'Optional note&hellip;', 'linkstash' ); ?>"><?php echo esc_textarea( $post->post_content ); ?></textarea>
+		<?php
+	}
+
+	/**
+	 * Persists the meta-box fields when a bookmark is saved.
+	 *
+	 * @param int     $post_id Bookmark post ID.
+	 * @param WP_Post $post    The saved post.
+	 *
+	 * @return void
+	 */
+	public function save_post( int $post_id, WP_Post $post ): void {
+		// Nonce verification happens in self::should_persist below; suppress
+		// PHPCS's per-line warnings about $_POST access since the gate at
+		// the top of this method already covers them.
+		// phpcs:disable WordPress.Security.NonceVerification.Missing
+		if ( ! self::should_persist( $post_id ) ) {
+			return;
+		}
+
+		$url       = self::read_text( 'linkstash_url' );
+		$canonical = Canonicalizer::canonicalize( $url );
+		if ( $url !== '' && $canonical !== '' ) {
+			update_post_meta( $post_id, BookmarkMeta::META_URL, esc_url_raw( $url ) );
+			update_post_meta( $post_id, BookmarkMeta::META_URL_CANONICAL, $canonical );
+		}
+
+		update_post_meta( $post_id, BookmarkMeta::META_UNREAD, isset( $_POST['linkstash_unread'] ) );
+		update_post_meta( $post_id, BookmarkMeta::META_ARCHIVED, isset( $_POST['linkstash_archived'] ) );
+
+		$note_raw = isset( $_POST['linkstash_note'] ) && \is_string( $_POST['linkstash_note'] )
+			? wp_kses_post( wp_unslash( $_POST['linkstash_note'] ) )
+			: '';
+		if ( $note_raw !== $post->post_content ) {
+			self::update_post_fields( $post_id, [ 'post_content' => $note_raw ] );
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		if ( \trim( $post->post_title ) === '' ) {
+			$resolved_url = $url !== '' ? $url : (string) get_post_meta( $post_id, BookmarkMeta::META_URL, true );
+			$display      = DisplayUrl::simplify( $resolved_url );
+			if ( $display !== '' ) {
+				self::update_post_fields( $post_id, [ 'post_title' => $display ] );
+			}
+		}
+	}
+}

--- a/src/Admin/BookmarkMetabox.php
+++ b/src/Admin/BookmarkMetabox.php
@@ -189,7 +189,8 @@ class BookmarkMetabox {
 					value="<?php echo esc_attr( $url ); ?>"
 					required
 					class="widefat"
-					placeholder="https://&hellip;" />
+					placeholder="https://&hellip;"
+					data-linkstash-url-input />
 		</p>
 		<p>
 			<label>

--- a/src/Admin/BookmarkMetabox.php
+++ b/src/Admin/BookmarkMetabox.php
@@ -10,6 +10,7 @@ use Apermo\LinkStash\PostType\BookmarkMeta;
 use Apermo\LinkStash\PostType\BookmarkPostType;
 use Apermo\LinkStash\Url\Canonicalizer;
 use Apermo\LinkStash\Url\DisplayUrl;
+use Apermo\LinkStash\Url\MetadataFetcher;
 use WP_Post;
 
 /**
@@ -25,6 +26,22 @@ class BookmarkMetabox {
 
 	private const NONCE_FIELD  = 'linkstash_metabox_nonce';
 	private const NONCE_ACTION = 'linkstash_save_metabox';
+
+	/**
+	 * URL metadata fetcher (used on save to mark unreachable URLs).
+	 *
+	 * @var MetadataFetcher
+	 */
+	private MetadataFetcher $fetcher;
+
+	/**
+	 * Constructs the metabox.
+	 *
+	 * @param MetadataFetcher $fetcher URL metadata fetcher.
+	 */
+	public function __construct( MetadataFetcher $fetcher ) {
+		$this->fetcher = $fetcher;
+	}
 
 	/**
 	 * Returns true when this save_post invocation should persist meta-box state.
@@ -155,9 +172,10 @@ class BookmarkMetabox {
 	 * @return void
 	 */
 	public function render_url_meta_box( WP_Post $post ): void {
-		$url      = (string) get_post_meta( $post->ID, BookmarkMeta::META_URL, true );
-		$unread   = (bool) get_post_meta( $post->ID, BookmarkMeta::META_UNREAD, true );
-		$archived = (bool) get_post_meta( $post->ID, BookmarkMeta::META_ARCHIVED, true );
+		$url         = (string) get_post_meta( $post->ID, BookmarkMeta::META_URL, true );
+		$unread      = (bool) get_post_meta( $post->ID, BookmarkMeta::META_UNREAD, true );
+		$archived    = (bool) get_post_meta( $post->ID, BookmarkMeta::META_ARCHIVED, true );
+		$unreachable = (bool) get_post_meta( $post->ID, BookmarkMeta::META_UNREACHABLE, true );
 		wp_nonce_field( self::NONCE_ACTION, self::NONCE_FIELD );
 		?>
 		<p>
@@ -171,6 +189,15 @@ class BookmarkMetabox {
 					placeholder="https://&hellip;"
 					data-linkstash-url-input />
 		</p>
+		<?php if ( $unreachable && $url !== '' ) { ?>
+			<div class="notice notice-warning inline" style="margin: 0.5rem 0; padding: 0.5rem 0.75rem;">
+				<p style="margin: 0;">
+					<strong><?php esc_html_e( 'URL didn\'t respond on last save.', 'linkstash' ); ?></strong>
+					<br />
+					<?php esc_html_e( 'It may be private, behind a VPN or login wall, or temporarily down. The bookmark is saved either way; re-saving will re-check.', 'linkstash' ); ?>
+				</p>
+			</div>
+		<?php } ?>
 		<p>
 			<label>
 				<input type="checkbox" name="linkstash_unread" value="1" <?php checked( $unread ); ?> />
@@ -226,8 +253,17 @@ class BookmarkMetabox {
 		$url       = self::read_text( 'linkstash_url' );
 		$canonical = Canonicalizer::canonicalize( $url );
 		if ( $url !== '' && $canonical !== '' ) {
+			$previous_canonical = (string) get_post_meta( $post_id, BookmarkMeta::META_URL_CANONICAL, true );
 			update_post_meta( $post_id, BookmarkMeta::META_URL, esc_url_raw( $url ) );
 			update_post_meta( $post_id, BookmarkMeta::META_URL_CANONICAL, $canonical );
+
+			// Re-check reachability whenever the URL actually changes. We
+			// don't refetch on every metabox save because the timeout
+			// (5s) would slow every "tweak the title" save to a crawl.
+			if ( $canonical !== $previous_canonical ) {
+				$result = $this->fetcher->fetch( $url );
+				update_post_meta( $post_id, BookmarkMeta::META_UNREACHABLE, ! $result['reachable'] );
+			}
 		}
 
 		update_post_meta( $post_id, BookmarkMeta::META_UNREAD, isset( $_POST['linkstash_unread'] ) );

--- a/src/Admin/BookmarkMetabox.php
+++ b/src/Admin/BookmarkMetabox.php
@@ -77,40 +77,19 @@ class BookmarkMetabox {
 	 * Updates the given post fields without re-triggering save_post handlers.
 	 *
 	 * Detaches our own save_post hook for the duration of the update so the
-	 * fallback-title write does not cause an infinite loop.
+	 * fallback-title write does not recurse into save_post.
 	 *
 	 * @param int                  $post_id Post ID.
 	 * @param array<string, mixed> $fields  Fields to update.
 	 *
 	 * @return void
 	 */
-	private static function update_post_fields( int $post_id, array $fields ): void {
-		$instance = null;
-		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-		global $wp_filter;
+	private function update_post_fields( int $post_id, array $fields ): void {
 		$hook_name = 'save_post_' . BookmarkPostType::POST_TYPE;
-		if ( isset( $wp_filter[ $hook_name ] ) ) {
-			foreach ( $wp_filter[ $hook_name ]->callbacks as $callbacks ) {
-				foreach ( $callbacks as $entry ) {
-					$callback = $entry['function'] ?? null;
-					if ( \is_array( $callback ) && $callback[0] instanceof self ) {
-						$instance = $callback[0];
-						break 2;
-					}
-				}
-			}
-		}
-		// phpcs:enable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
-		if ( $instance !== null ) {
-			remove_action( $hook_name, [ $instance, 'save_post' ], 10 );
-		}
-
+		remove_action( $hook_name, [ $this, 'save_post' ], 10 );
 		wp_update_post( \array_merge( [ 'ID' => $post_id ], $fields ) );
-
-		if ( $instance !== null ) {
-			add_action( $hook_name, [ $instance, 'save_post' ], 10, 2 );
-		}
+		add_action( $hook_name, [ $this, 'save_post' ], 10, 2 );
 	}
 
 	/**
@@ -257,17 +236,23 @@ class BookmarkMetabox {
 		$note_raw = isset( $_POST['linkstash_note'] ) && \is_string( $_POST['linkstash_note'] )
 			? wp_kses_post( wp_unslash( $_POST['linkstash_note'] ) )
 			: '';
-		if ( $note_raw !== $post->post_content ) {
-			self::update_post_fields( $post_id, [ 'post_content' => $note_raw ] );
-		}
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		$update = [];
+		if ( $note_raw !== $post->post_content ) {
+			$update['post_content'] = $note_raw;
+		}
 
 		if ( \trim( $post->post_title ) === '' ) {
 			$resolved_url = $url !== '' ? $url : (string) get_post_meta( $post_id, BookmarkMeta::META_URL, true );
 			$display      = DisplayUrl::simplify( $resolved_url );
 			if ( $display !== '' ) {
-				self::update_post_fields( $post_id, [ 'post_title' => $display ] );
+				$update['post_title'] = $display;
 			}
+		}
+
+		if ( $update !== [] ) {
+			$this->update_post_fields( $post_id, $update );
 		}
 	}
 }

--- a/src/Admin/BookmarkMetabox.php
+++ b/src/Admin/BookmarkMetabox.php
@@ -253,17 +253,15 @@ class BookmarkMetabox {
 		$url       = self::read_text( 'linkstash_url' );
 		$canonical = Canonicalizer::canonicalize( $url );
 		if ( $url !== '' && $canonical !== '' ) {
-			$previous_canonical = (string) get_post_meta( $post_id, BookmarkMeta::META_URL_CANONICAL, true );
 			update_post_meta( $post_id, BookmarkMeta::META_URL, esc_url_raw( $url ) );
 			update_post_meta( $post_id, BookmarkMeta::META_URL_CANONICAL, $canonical );
 
-			// Re-check reachability whenever the URL actually changes. We
-			// don't refetch on every metabox save because the timeout
-			// (5s) would slow every "tweak the title" save to a crawl.
-			if ( $canonical !== $previous_canonical ) {
-				$result = $this->fetcher->fetch( $url );
-				update_post_meta( $post_id, BookmarkMeta::META_UNREACHABLE, ! $result['reachable'] );
-			}
+			// Re-check reachability on every save, even when the URL
+			// itself didn't change — a previously-down host coming back
+			// up should clear the warning automatically the next time
+			// the user touches the bookmark.
+			$result = $this->fetcher->fetch( $url );
+			update_post_meta( $post_id, BookmarkMeta::META_UNREACHABLE, ! $result['reachable'] );
 		}
 
 		update_post_meta( $post_id, BookmarkMeta::META_UNREAD, isset( $_POST['linkstash_unread'] ) );

--- a/src/Admin/BookmarkMetabox.php
+++ b/src/Admin/BookmarkMetabox.php
@@ -146,12 +146,15 @@ class BookmarkMetabox {
 	 * @return void
 	 */
 	public function register_meta_boxes(): void {
+		// Both meta boxes live in the main (normal) column. The URL panel
+		// uses 'high' priority so it renders directly under the title and
+		// above the Notes panel.
 		add_meta_box(
 			'linkstash_bookmark_url',
 			__( 'Bookmark URL', 'linkstash' ),
 			[ $this, 'render_url_meta_box' ],
 			BookmarkPostType::POST_TYPE,
-			'side',
+			'normal',
 			'high',
 		);
 

--- a/src/Admin/DashboardWidget.php
+++ b/src/Admin/DashboardWidget.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\LinkStash\Admin;
+
+\defined( 'ABSPATH' ) || exit();
+
+/**
+ * Adds a "Quick Bookmark" widget to the WordPress admin dashboard.
+ *
+ * Mirrors core's Quick Draft widget: a small paste-a-URL form that posts
+ * to the same `linkstash_quick_add` admin-post handler used by the bookmark
+ * list-screen quick-add. The form HTML is reused via
+ * {@see QuickAdd::render_form_html} so behaviour stays in lockstep.
+ */
+class DashboardWidget {
+
+	private const WIDGET_ID = 'linkstash_quick_bookmark';
+
+	/**
+	 * Hooks the dashboard setup.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_action( 'wp_dashboard_setup', [ $this, 'register_widget' ] );
+	}
+
+	/**
+	 * Registers the widget with the dashboard, gated on `edit_posts`.
+	 *
+	 * @return void
+	 */
+	public function register_widget(): void {
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return;
+		}
+
+		wp_add_dashboard_widget(
+			self::WIDGET_ID,
+			__( 'Quick Bookmark', 'linkstash' ),
+			[ $this, 'render' ],
+		);
+	}
+
+	/**
+	 * Renders the dashboard widget body.
+	 *
+	 * @return void
+	 */
+	public function render(): void {
+		echo '<p>' . esc_html__( 'Save a URL to your bookmark library.', 'linkstash' ) . '</p>';
+		QuickAdd::render_form_html( 'linkstash-dashboard-widget' );
+	}
+}

--- a/src/Admin/QuickAdd.php
+++ b/src/Admin/QuickAdd.php
@@ -94,7 +94,7 @@ class QuickAdd {
 			<input type="hidden" name="action" value="<?php echo esc_attr( self::ACTION ); ?>" />
 			<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( $nonce ); ?>" />
 			<p>
-				<input type="url" name="url" placeholder="<?php esc_attr_e( 'https://…', 'linkstash' ); ?>" required class="widefat" />
+				<input type="url" name="url" placeholder="<?php esc_attr_e( 'https://…', 'linkstash' ); ?>" required class="widefat" data-linkstash-url-input />
 			</p>
 			<p>
 				<input type="text" name="tags" placeholder="<?php esc_attr_e( 'tags, comma, separated', 'linkstash' ); ?>" class="widefat" data-linkstash-tag-autocomplete="<?php echo esc_attr( TagTaxonomy::TAXONOMY ); ?>" autocomplete="off" />

--- a/src/Admin/QuickAdd.php
+++ b/src/Admin/QuickAdd.php
@@ -194,6 +194,7 @@ class QuickAdd {
 		update_post_meta( $post_id, BookmarkMeta::META_URL_CANONICAL, $canonical );
 		update_post_meta( $post_id, BookmarkMeta::META_UNREAD, false );
 		update_post_meta( $post_id, BookmarkMeta::META_ARCHIVED, false );
+		update_post_meta( $post_id, BookmarkMeta::META_UNREACHABLE, ! $meta['reachable'] );
 
 		if ( $tags !== [] ) {
 			wp_set_object_terms( $post_id, $tags, TagTaxonomy::TAXONOMY, false );

--- a/src/Admin/QuickAdd.php
+++ b/src/Admin/QuickAdd.php
@@ -78,6 +78,39 @@ class QuickAdd {
 	}
 
 	/**
+	 * Renders the standalone quick-add form HTML.
+	 *
+	 * Shared by the bookmark list screen and the dashboard widget so the
+	 * markup, nonce, and submit target stay in lockstep.
+	 *
+	 * @param string $css_class Extra CSS class to apply to the form element.
+	 *
+	 * @return void
+	 */
+	public static function render_form_html( string $css_class = 'linkstash-quick-add' ): void {
+		$nonce = wp_create_nonce( self::ACTION );
+		?>
+		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="<?php echo esc_attr( $css_class ); ?>" style="margin: 0.5rem 0;">
+			<input type="hidden" name="action" value="<?php echo esc_attr( self::ACTION ); ?>" />
+			<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( $nonce ); ?>" />
+			<p>
+				<input type="url" name="url" placeholder="<?php esc_attr_e( 'https://…', 'linkstash' ); ?>" required class="widefat" />
+			</p>
+			<p>
+				<input type="text" name="tags" placeholder="<?php esc_attr_e( 'tags, comma, separated', 'linkstash' ); ?>" class="widefat" />
+			</p>
+			<p>
+				<label>
+					<input type="checkbox" name="public" value="1" />
+					<?php esc_html_e( 'Public', 'linkstash' ); ?>
+				</label>
+				<button type="submit" class="button button-primary alignright"><?php esc_html_e( 'Save bookmark', 'linkstash' ); ?></button>
+			</p>
+		</form>
+		<?php
+	}
+
+	/**
 	 * Hooks the rendering and submission handlers.
 	 *
 	 * @return void
@@ -107,20 +140,7 @@ class QuickAdd {
 			return;
 		}
 
-		$nonce = wp_create_nonce( self::ACTION );
-		?>
-		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="linkstash-quick-add" style="margin: 0.5rem 0;">
-			<input type="hidden" name="action" value="<?php echo esc_attr( self::ACTION ); ?>" />
-			<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( $nonce ); ?>" />
-			<input type="url" name="url" placeholder="<?php esc_attr_e( 'https://…', 'linkstash' ); ?>" required style="min-width: 18rem;" />
-			<input type="text" name="tags" placeholder="<?php esc_attr_e( 'tags, comma, separated', 'linkstash' ); ?>" />
-			<label style="margin-left: 0.5rem;">
-				<input type="checkbox" name="public" value="1" />
-				<?php esc_html_e( 'Public', 'linkstash' ); ?>
-			</label>
-			<button type="submit" class="button button-primary"><?php esc_html_e( 'Save bookmark', 'linkstash' ); ?></button>
-		</form>
-		<?php
+		self::render_form_html( 'linkstash-quick-add' );
 	}
 
 	/**

--- a/src/Admin/QuickAdd.php
+++ b/src/Admin/QuickAdd.php
@@ -97,7 +97,7 @@ class QuickAdd {
 				<input type="url" name="url" placeholder="<?php esc_attr_e( 'https://…', 'linkstash' ); ?>" required class="widefat" />
 			</p>
 			<p>
-				<input type="text" name="tags" placeholder="<?php esc_attr_e( 'tags, comma, separated', 'linkstash' ); ?>" class="widefat" />
+				<input type="text" name="tags" placeholder="<?php esc_attr_e( 'tags, comma, separated', 'linkstash' ); ?>" class="widefat" data-linkstash-tag-autocomplete="<?php echo esc_attr( TagTaxonomy::TAXONOMY ); ?>" autocomplete="off" />
 			</p>
 			<p>
 				<label>

--- a/src/Admin/TagAutocomplete.php
+++ b/src/Admin/TagAutocomplete.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\LinkStash\Admin;
+
+use Apermo\LinkStash\PostType\BookmarkPostType;
+use Apermo\LinkStash\PostType\TagTaxonomy;
+
+\defined( 'ABSPATH' ) || exit();
+
+/**
+ * Wires jQuery UI autocomplete to the comma-separated tags inputs in the
+ * dashboard widget and the bookmark list-screen quick-add form.
+ *
+ * Backs onto WordPress's existing `ajax-tag-search` admin-ajax endpoint,
+ * which natively understands any taxonomy registered with `show_ui` true
+ * — so all we contribute is the script enqueue and a small adapter that
+ * suggests against only the last comma-separated segment of the input.
+ *
+ * The bookmark edit screen relies on core's standard taxonomy meta box,
+ * which already ships its own autocomplete; this class only targets the
+ * standalone forms.
+ */
+class TagAutocomplete {
+
+	/**
+	 * Returns true when the current screen renders one of the quick-add forms.
+	 *
+	 * @param string $hook Hook suffix passed to admin_enqueue_scripts.
+	 *
+	 * @return bool
+	 */
+	private static function is_target_screen( string $hook ): bool {
+		if ( $hook === 'index.php' ) {
+			return true;
+		}
+
+		if ( $hook !== 'edit.php' ) {
+			return false;
+		}
+
+		$screen = \function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+
+		return $screen !== null && $screen->post_type === BookmarkPostType::POST_TYPE;
+	}
+
+	/**
+	 * Returns minimal CSS for the autocomplete dropdown.
+	 *
+	 * WordPress doesn't bundle the full jQuery UI base stylesheet, so the
+	 * dropdown would otherwise render unstyled. This is enough to give it
+	 * an admin-coloured panel with a hover state — no external assets.
+	 *
+	 * @return string
+	 */
+	private static function dropdown_css(): string {
+		return '.ui-autocomplete{background:#fff;border:1px solid #c3c4c7;list-style:none;margin:0;padding:0;position:absolute;z-index:9999;box-shadow:0 2px 4px rgba(0,0,0,0.08);max-height:14rem;overflow-y:auto}.ui-autocomplete .ui-menu-item{padding:6px 10px;cursor:pointer}.ui-autocomplete .ui-menu-item.ui-state-active,.ui-autocomplete .ui-menu-item:hover{background:#2271b1;color:#fff}';
+	}
+
+	/**
+	 * Returns the inline adapter script that wires jQuery UI autocomplete
+	 * to inputs marked with `data-linkstash-tag-autocomplete="<taxonomy>"`.
+	 *
+	 * @return string
+	 */
+	private static function adapter_js(): string {
+		$taxonomy = TagTaxonomy::TAXONOMY;
+
+		return <<<JS
+( function ( \$ ) {
+	\$( function () {
+		\$( 'input[data-linkstash-tag-autocomplete]' ).each( function () {
+			var \$input = \$( this );
+			var taxonomy = \$input.data( 'linkstashTagAutocomplete' ) || '{$taxonomy}';
+			\$input.autocomplete( {
+				minLength: 1,
+				source: function ( request, response ) {
+					var term = request.term.split( /,\\s*/ ).pop();
+					if ( term.length < 1 ) {
+						response( [] );
+						return;
+					}
+					\$.get( window.ajaxurl, {
+						action: 'ajax-tag-search',
+						tax: taxonomy,
+						q: term
+					}, function ( data ) {
+						response( ( data || '' ).split( '\\n' ).filter( Boolean ) );
+					} );
+				},
+				search: function () {
+					var term = this.value.split( /,\\s*/ ).pop();
+					if ( term.length < 1 ) {
+						return false;
+					}
+				},
+				focus: function () { return false; },
+				select: function ( event, ui ) {
+					var terms = this.value.split( /,\\s*/ );
+					terms.pop();
+					terms.push( ui.item.value );
+					terms.push( '' );
+					this.value = terms.join( ', ' );
+					return false;
+				}
+			} );
+		} );
+	} );
+} )( jQuery );
+JS;
+	}
+
+	/**
+	 * Hooks the script enqueue.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_action( 'admin_enqueue_scripts', [ $this, 'maybe_enqueue' ] );
+	}
+
+	/**
+	 * Enqueues jQuery UI autocomplete + adapter on the screens that show
+	 * a quick-add form (dashboard, bookmark list table).
+	 *
+	 * @param string $hook Current admin screen hook suffix.
+	 *
+	 * @return void
+	 */
+	public function maybe_enqueue( string $hook ): void {
+		if ( ! self::is_target_screen( $hook ) ) {
+			return;
+		}
+
+		wp_enqueue_script( 'jquery-ui-autocomplete' );
+		wp_add_inline_script( 'jquery-ui-autocomplete', self::adapter_js() );
+		wp_register_style( 'linkstash-tag-autocomplete', false, [], '0.1.0' );
+		wp_enqueue_style( 'linkstash-tag-autocomplete' );
+		wp_add_inline_style( 'linkstash-tag-autocomplete', self::dropdown_css() );
+	}
+}

--- a/src/Admin/UrlAutoScheme.php
+++ b/src/Admin/UrlAutoScheme.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\LinkStash\Admin;
+
+use Apermo\LinkStash\PostType\BookmarkPostType;
+
+\defined( 'ABSPATH' ) || exit();
+
+/**
+ * Prepends `https://` to bare URL inputs when the user tabs away.
+ *
+ * Saves the user from typing the scheme on every quick-add. Targets any
+ * `<input type="url">` that opts in via `data-linkstash-url-input`. The
+ * blur handler is conservative: it leaves anything that already looks
+ * scheme-prefixed alone (`http://`, `https://`, `mailto:`, `//host/...`,
+ * etc.).
+ */
+class UrlAutoScheme {
+
+	/**
+	 * Returns true on screens that render a LinkStash URL input.
+	 *
+	 * @param string $hook Hook suffix passed to admin_enqueue_scripts.
+	 *
+	 * @return bool
+	 */
+	private static function is_target_screen( string $hook ): bool {
+		// Dashboard always runs the quick-add widget.
+		if ( $hook === 'index.php' ) {
+			return true;
+		}
+
+		if ( ! \in_array( $hook, [ 'edit.php', 'post.php', 'post-new.php' ], true ) ) {
+			return false;
+		}
+
+		$screen = \function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+
+		return $screen !== null && $screen->post_type === BookmarkPostType::POST_TYPE;
+	}
+
+	/**
+	 * Returns the inline blur handler.
+	 *
+	 * @return string
+	 */
+	private static function handler_js(): string {
+		return <<<'JS'
+( function () {
+	function attach( input ) {
+		input.addEventListener( 'blur', function () {
+			var value = input.value.trim();
+			if ( value === '' ) { return; }
+			// Already scheme-prefixed (http://, mailto:, chrome-extension://, …) or protocol-relative — leave alone.
+			if ( /^[a-z][a-z0-9+.\-]*:|^\/\//i.test( value ) ) { return; }
+			input.value = 'https://' + value;
+		} );
+	}
+	function init() {
+		document.querySelectorAll( 'input[data-linkstash-url-input]' ).forEach( attach );
+	}
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', init );
+	} else {
+		init();
+	}
+} )();
+JS;
+	}
+
+	/**
+	 * Hooks the script enqueue.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_action( 'admin_enqueue_scripts', [ $this, 'maybe_enqueue' ] );
+	}
+
+	/**
+	 * Enqueues the blur-handler script on every screen that renders a
+	 * LinkStash URL input.
+	 *
+	 * @param string $hook Current admin screen hook suffix.
+	 *
+	 * @return void
+	 */
+	public function maybe_enqueue( string $hook ): void {
+		if ( ! self::is_target_screen( $hook ) ) {
+			return;
+		}
+
+		wp_register_script( 'linkstash-url-auto-scheme', false, [], '0.1.0', true );
+		wp_enqueue_script( 'linkstash-url-auto-scheme' );
+		wp_add_inline_script( 'linkstash-url-auto-scheme', self::handler_js() );
+	}
+}

--- a/src/Main.php
+++ b/src/Main.php
@@ -110,7 +110,7 @@ class Main {
 			( new Notices() )->register();
 			( new QuickAdd( new MetadataFetcher() ) )->register();
 			( new SettingsPage( $store ) )->register();
-			( new BookmarkMetabox() )->register();
+			( new BookmarkMetabox( new MetadataFetcher() ) )->register();
 			( new DashboardWidget() )->register();
 			( new TagAutocomplete() )->register();
 			( new UrlAutoScheme() )->register();

--- a/src/Main.php
+++ b/src/Main.php
@@ -12,6 +12,7 @@ use Apermo\LinkStash\Admin\ListColumns;
 use Apermo\LinkStash\Admin\Notices;
 use Apermo\LinkStash\Admin\QuickAdd;
 use Apermo\LinkStash\Admin\SettingsPage;
+use Apermo\LinkStash\Admin\TagAutocomplete;
 use Apermo\LinkStash\Auth\BearerTokenAuth;
 use Apermo\LinkStash\Auth\TokenStore;
 use Apermo\LinkStash\PostType\BookmarkMeta;
@@ -110,6 +111,7 @@ class Main {
 			( new SettingsPage( $store ) )->register();
 			( new BookmarkMetabox() )->register();
 			( new DashboardWidget() )->register();
+			( new TagAutocomplete() )->register();
 		}
 	}
 }

--- a/src/Main.php
+++ b/src/Main.php
@@ -6,6 +6,7 @@ namespace Apermo\LinkStash;
 
 \defined( 'ABSPATH' ) || exit();
 
+use Apermo\LinkStash\Admin\BookmarkMetabox;
 use Apermo\LinkStash\Admin\ListColumns;
 use Apermo\LinkStash\Admin\Notices;
 use Apermo\LinkStash\Admin\QuickAdd;
@@ -106,6 +107,7 @@ class Main {
 			( new Notices() )->register();
 			( new QuickAdd( new MetadataFetcher() ) )->register();
 			( new SettingsPage( $store ) )->register();
+			( new BookmarkMetabox() )->register();
 		}
 	}
 }

--- a/src/Main.php
+++ b/src/Main.php
@@ -7,6 +7,7 @@ namespace Apermo\LinkStash;
 \defined( 'ABSPATH' ) || exit();
 
 use Apermo\LinkStash\Admin\BookmarkMetabox;
+use Apermo\LinkStash\Admin\DashboardWidget;
 use Apermo\LinkStash\Admin\ListColumns;
 use Apermo\LinkStash\Admin\Notices;
 use Apermo\LinkStash\Admin\QuickAdd;
@@ -108,6 +109,7 @@ class Main {
 			( new QuickAdd( new MetadataFetcher() ) )->register();
 			( new SettingsPage( $store ) )->register();
 			( new BookmarkMetabox() )->register();
+			( new DashboardWidget() )->register();
 		}
 	}
 }

--- a/src/Main.php
+++ b/src/Main.php
@@ -13,6 +13,7 @@ use Apermo\LinkStash\Admin\Notices;
 use Apermo\LinkStash\Admin\QuickAdd;
 use Apermo\LinkStash\Admin\SettingsPage;
 use Apermo\LinkStash\Admin\TagAutocomplete;
+use Apermo\LinkStash\Admin\UrlAutoScheme;
 use Apermo\LinkStash\Auth\BearerTokenAuth;
 use Apermo\LinkStash\Auth\TokenStore;
 use Apermo\LinkStash\PostType\BookmarkMeta;
@@ -112,6 +113,7 @@ class Main {
 			( new BookmarkMetabox() )->register();
 			( new DashboardWidget() )->register();
 			( new TagAutocomplete() )->register();
+			( new UrlAutoScheme() )->register();
 		}
 	}
 }

--- a/src/PostType/BookmarkMeta.php
+++ b/src/PostType/BookmarkMeta.php
@@ -15,6 +15,53 @@ class BookmarkMeta {
 	public const META_URL_CANONICAL = '_linkstash_url_canonical';
 	public const META_UNREAD        = '_linkstash_unread';
 	public const META_ARCHIVED      = '_linkstash_archived';
+	public const META_UNREACHABLE   = '_linkstash_unreachable';
+
+	/**
+	 * Registers a single-value string meta with REST exposure.
+	 *
+	 * @param string          $key      Meta key.
+	 * @param callable():bool $auth_cb Auth callback.
+	 *
+	 * @return void
+	 */
+	private static function register_string_meta( string $key, callable $auth_cb ): void {
+		register_post_meta(
+			BookmarkPostType::POST_TYPE,
+			$key,
+			[
+				'type'              => 'string',
+				'single'            => true,
+				'show_in_rest'      => true,
+				'sanitize_callback' => 'esc_url_raw',
+				'auth_callback'     => $auth_cb,
+				'default'           => '',
+			],
+		);
+	}
+
+	/**
+	 * Registers a single-value boolean meta with REST exposure.
+	 *
+	 * @param string          $key      Meta key.
+	 * @param callable():bool $auth_cb Auth callback.
+	 *
+	 * @return void
+	 */
+	private static function register_bool_meta( string $key, callable $auth_cb ): void {
+		register_post_meta(
+			BookmarkPostType::POST_TYPE,
+			$key,
+			[
+				'type'              => 'boolean',
+				'single'            => true,
+				'show_in_rest'      => true,
+				'sanitize_callback' => 'rest_sanitize_boolean',
+				'auth_callback'     => $auth_cb,
+				'default'           => false,
+			],
+		);
+	}
 
 	/**
 	 * Registers the WordPress hook that triggers meta registration.
@@ -33,56 +80,10 @@ class BookmarkMeta {
 	public function register_post_meta(): void {
 		$auth_callback = static fn (): bool => current_user_can( 'edit_posts' );
 
-		register_post_meta(
-			BookmarkPostType::POST_TYPE,
-			self::META_URL,
-			[
-				'type'              => 'string',
-				'single'            => true,
-				'show_in_rest'      => true,
-				'sanitize_callback' => 'esc_url_raw',
-				'auth_callback'     => $auth_callback,
-				'default'           => '',
-			],
-		);
-
-		register_post_meta(
-			BookmarkPostType::POST_TYPE,
-			self::META_URL_CANONICAL,
-			[
-				'type'              => 'string',
-				'single'            => true,
-				'show_in_rest'      => true,
-				'sanitize_callback' => 'esc_url_raw',
-				'auth_callback'     => $auth_callback,
-				'default'           => '',
-			],
-		);
-
-		register_post_meta(
-			BookmarkPostType::POST_TYPE,
-			self::META_UNREAD,
-			[
-				'type'              => 'boolean',
-				'single'            => true,
-				'show_in_rest'      => true,
-				'sanitize_callback' => 'rest_sanitize_boolean',
-				'auth_callback'     => $auth_callback,
-				'default'           => false,
-			],
-		);
-
-		register_post_meta(
-			BookmarkPostType::POST_TYPE,
-			self::META_ARCHIVED,
-			[
-				'type'              => 'boolean',
-				'single'            => true,
-				'show_in_rest'      => true,
-				'sanitize_callback' => 'rest_sanitize_boolean',
-				'auth_callback'     => $auth_callback,
-				'default'           => false,
-			],
-		);
+		self::register_string_meta( self::META_URL, $auth_callback );
+		self::register_string_meta( self::META_URL_CANONICAL, $auth_callback );
+		self::register_bool_meta( self::META_UNREAD, $auth_callback );
+		self::register_bool_meta( self::META_ARCHIVED, $auth_callback );
+		self::register_bool_meta( self::META_UNREACHABLE, $auth_callback );
 	}
 }

--- a/src/PostType/BookmarkPostType.php
+++ b/src/PostType/BookmarkPostType.php
@@ -57,7 +57,7 @@ class BookmarkPostType {
 				'menu_icon'          => 'dashicons-admin-links',
 				'capability_type'    => 'post',
 				'map_meta_cap'       => true,
-				'supports'           => [ 'title', 'editor', 'custom-fields' ],
+				'supports'           => [ 'title' ],
 				'has_archive'        => false,
 				'hierarchical'       => false,
 				'rewrite'            => false,

--- a/src/Url/DisplayUrl.php
+++ b/src/Url/DisplayUrl.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Apermo\LinkStash\Url;
 
+\defined( 'ABSPATH' ) || exit();
+
 /**
  * Renders a URL as a short, human-readable string for display fallbacks.
  *

--- a/src/Url/DisplayUrl.php
+++ b/src/Url/DisplayUrl.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\LinkStash\Url;
+
+/**
+ * Renders a URL as a short, human-readable string for display fallbacks.
+ *
+ * Used as the bookmark title fallback when the user does not provide an
+ * explicit label. Distinct from {@see Canonicalizer}: canonicalization
+ * preserves enough of the URL to compare two links for dedupe identity
+ * (sorted query, scheme, port); display drops everything that does not
+ * help a human recognise the page.
+ */
+class DisplayUrl {
+
+	/**
+	 * Returns a short, human-readable form of the given URL.
+	 *
+	 * Strips scheme, leading `www.`, query string, and fragment. Lowercases
+	 * the host and trims a single trailing slash from the path. Returns
+	 * the original input unchanged when the URL cannot be parsed.
+	 *
+	 * @param string $url Input URL.
+	 *
+	 * @return string
+	 */
+	public static function simplify( string $url ): string {
+		if ( $url === '' ) {
+			return '';
+		}
+
+		$parts = wp_parse_url( $url );
+		if ( ! \is_array( $parts ) || ! isset( $parts['host'] ) ) {
+			return $url;
+		}
+
+		$host = \strtolower( $parts['host'] );
+		if ( \str_starts_with( $host, 'www.' ) ) {
+			$host = \substr( $host, 4 );
+		}
+
+		$path = $parts['path'] ?? '';
+		if ( $path === '/' ) {
+			$path = '';
+		} elseif ( \str_ends_with( $path, '/' ) ) {
+			$path = \rtrim( $path, '/' );
+		}
+
+		return $host . $path;
+	}
+}

--- a/tests/Unit/Admin/BookmarkMetaboxTest.php
+++ b/tests/Unit/Admin/BookmarkMetaboxTest.php
@@ -1,0 +1,297 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\LinkStash\Tests\Unit\Admin;
+
+use Apermo\LinkStash\Admin\BookmarkMetabox;
+use Apermo\LinkStash\PostType\BookmarkMeta;
+use Apermo\LinkStash\PostType\BookmarkPostType;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use WP_Post;
+
+/**
+ * Tests the bookmark edit-screen metabox class.
+ */
+class BookmarkMetaboxTest extends TestCase {
+
+	/**
+	 * Holds the recorded update_post_meta calls.
+	 *
+	 * @var array<int, array{0: int, 1: string, 2: mixed}>
+	 */
+	private array $meta_writes = [];
+
+	/**
+	 * Holds the recorded wp_update_post calls.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	private array $post_writes = [];
+
+	/**
+	 * Sets up Brain Monkey and a permissive set of WP stubs.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		$_POST = [];
+
+		$this->meta_writes = [];
+		$this->post_writes = [];
+
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'esc_attr' )->returnArg();
+		Functions\when( 'esc_attr_e' )->alias(
+			static function ( $value ): void {
+				echo $value; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- test stub.
+			},
+		);
+		Functions\when( 'esc_html_e' )->alias(
+			static function ( $value ): void {
+				echo $value; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- test stub.
+			},
+		);
+		Functions\when( 'esc_textarea' )->returnArg();
+		Functions\when( 'esc_url_raw' )->returnArg();
+		Functions\when( 'wp_kses_post' )->returnArg();
+		Functions\when( 'wp_unslash' )->returnArg();
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'wp_parse_url' )->alias( static fn ( string $url ) => \parse_url( $url ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
+		Functions\when( 'checked' )->alias(
+			static function ( $value, $compare = true ): string {
+				return $value === $compare ? "checked='checked'" : '';
+			},
+		);
+		Functions\when( 'wp_nonce_field' )->justReturn( '' );
+		Functions\when( 'wp_verify_nonce' )->justReturn( true );
+		Functions\when( 'wp_is_post_revision' )->justReturn( false );
+		Functions\when( 'current_user_can' )->justReturn( true );
+
+		Functions\when( 'get_post_meta' )->justReturn( '' );
+
+		$writes = &$this->meta_writes;
+		Functions\when( 'update_post_meta' )->alias(
+			static function ( int $post_id, string $key, $value ) use ( &$writes ): bool {
+				$writes[] = [ $post_id, $key, $value ];
+				return true;
+			},
+		);
+
+		$post_writes = &$this->post_writes;
+		Functions\when( 'wp_update_post' )->alias(
+			static function ( array $args ) use ( &$post_writes ): int {
+				$post_writes[] = $args;
+				return (int) ( $args['ID'] ?? 0 );
+			},
+		);
+	}
+
+	/**
+	 * Tears down Brain Monkey.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+		$_POST = [];
+	}
+
+	/**
+	 * Verifies register hooks the meta-box registration, save handler, and editor filter.
+	 *
+	 * @return void
+	 */
+	public function test_register_hooks_admin_actions(): void {
+		$metabox = new BookmarkMetabox();
+		$metabox->register();
+
+		$post_type = BookmarkPostType::POST_TYPE;
+		self::assertNotFalse( has_action( "add_meta_boxes_{$post_type}", [ $metabox, 'register_meta_boxes' ] ) );
+		self::assertNotFalse( has_action( "save_post_{$post_type}", [ $metabox, 'save_post' ] ) );
+		self::assertNotFalse( has_filter( 'use_block_editor_for_post_type', [ $metabox, 'disable_block_editor' ] ) );
+	}
+
+	/**
+	 * Verifies the editor filter returns false for the bookmark CPT only.
+	 *
+	 * @return void
+	 */
+	public function test_disable_block_editor_only_for_bookmark_cpt(): void {
+		$metabox = new BookmarkMetabox();
+
+		self::assertFalse( $metabox->disable_block_editor( true, BookmarkPostType::POST_TYPE ) );
+		self::assertTrue( $metabox->disable_block_editor( true, 'post' ) );
+		self::assertFalse( $metabox->disable_block_editor( false, 'post' ) );
+	}
+
+	/**
+	 * Verifies register_meta_boxes calls add_meta_box for both panels.
+	 *
+	 * @return void
+	 */
+	public function test_register_meta_boxes(): void {
+		Functions\expect( 'add_meta_box' )->twice();
+
+		( new BookmarkMetabox() )->register_meta_boxes();
+	}
+
+	/**
+	 * Verifies the URL meta box renders the URL, unread, and archived inputs.
+	 *
+	 * @return void
+	 */
+	public function test_render_url_meta_box_outputs_inputs(): void {
+		Functions\when( 'get_post_meta' )->alias(
+			static fn ( int $post_id, string $key ) => match ( $key ) {
+				BookmarkMeta::META_URL      => 'https://example.tld',
+				BookmarkMeta::META_UNREAD   => true,
+				BookmarkMeta::META_ARCHIVED => false,
+				default                     => '',
+			},
+		);
+
+		$post     = new WP_Post();
+		$post->ID = 7;
+
+		\ob_start();
+		( new BookmarkMetabox() )->render_url_meta_box( $post );
+		$output = (string) \ob_get_clean();
+
+		self::assertStringContainsString( 'name="linkstash_url"', $output );
+		self::assertStringContainsString( 'value="https://example.tld"', $output );
+		self::assertStringContainsString( 'name="linkstash_unread"', $output );
+		self::assertStringContainsString( 'name="linkstash_archived"', $output );
+	}
+
+	/**
+	 * Verifies the Notes meta box renders the post content in a textarea.
+	 *
+	 * @return void
+	 */
+	public function test_render_note_meta_box(): void {
+		$post               = new WP_Post();
+		$post->ID           = 7;
+		$post->post_content = 'These are my notes.';
+
+		\ob_start();
+		( new BookmarkMetabox() )->render_note_meta_box( $post );
+		$output = (string) \ob_get_clean();
+
+		self::assertStringContainsString( '<textarea', $output );
+		self::assertStringContainsString( 'These are my notes.', $output );
+	}
+
+	/**
+	 * Verifies save_post bails when no nonce is present.
+	 *
+	 * @return void
+	 */
+	public function test_save_post_bails_without_nonce(): void {
+		$post     = new WP_Post();
+		$post->ID = 7;
+
+		( new BookmarkMetabox() )->save_post( 7, $post );
+
+		self::assertSame( [], $this->meta_writes );
+		self::assertSame( [], $this->post_writes );
+	}
+
+	/**
+	 * Verifies save_post persists the URL, canonical URL, and flag meta when the form posts a URL.
+	 *
+	 * @return void
+	 */
+	public function test_save_post_persists_url_and_flags(): void {
+		$_POST = [
+			'linkstash_metabox_nonce' => 'nonce',
+			'linkstash_url'           => 'https://www.example.tld/article',
+			'linkstash_unread'        => '1',
+		];
+
+		$post               = new WP_Post();
+		$post->ID           = 7;
+		$post->post_title   = 'My title';
+		$post->post_content = '';
+
+		( new BookmarkMetabox() )->save_post( 7, $post );
+
+		$keys = \array_column( $this->meta_writes, 1 );
+		self::assertContains( BookmarkMeta::META_URL, $keys );
+		self::assertContains( BookmarkMeta::META_URL_CANONICAL, $keys );
+		self::assertContains( BookmarkMeta::META_UNREAD, $keys );
+		self::assertContains( BookmarkMeta::META_ARCHIVED, $keys );
+
+		// Title was non-empty, so we should NOT have rewritten it.
+		$post_title_writes = \array_filter(
+			$this->post_writes,
+			static fn ( array $write ): bool => isset( $write['post_title'] ),
+		);
+		self::assertSame( [], $post_title_writes );
+	}
+
+	/**
+	 * Verifies save_post derives a fallback title from the URL when the title is empty.
+	 *
+	 * @return void
+	 */
+	public function test_save_post_derives_fallback_title(): void {
+		$_POST = [
+			'linkstash_metabox_nonce' => 'nonce',
+			'linkstash_url'           => 'https://www.example.tld/blog/article',
+		];
+
+		$post               = new WP_Post();
+		$post->ID           = 7;
+		$post->post_title   = '';
+		$post->post_content = '';
+
+		( new BookmarkMetabox() )->save_post( 7, $post );
+
+		$title_write = null;
+		foreach ( $this->post_writes as $write ) {
+			if ( isset( $write['post_title'] ) ) {
+				$title_write = $write['post_title'];
+				break;
+			}
+		}
+
+		self::assertSame( 'example.tld/blog/article', $title_write );
+	}
+
+	/**
+	 * Verifies save_post persists notes only when they differ from the existing content.
+	 *
+	 * @return void
+	 */
+	public function test_save_post_persists_notes(): void {
+		$_POST = [
+			'linkstash_metabox_nonce' => 'nonce',
+			'linkstash_url'           => 'https://example.tld',
+			'linkstash_note'          => 'New notes',
+		];
+
+		$post               = new WP_Post();
+		$post->ID           = 7;
+		$post->post_title   = 'T';
+		$post->post_content = 'Old notes';
+
+		( new BookmarkMetabox() )->save_post( 7, $post );
+
+		$content_write = null;
+		foreach ( $this->post_writes as $write ) {
+			if ( isset( $write['post_content'] ) ) {
+				$content_write = $write['post_content'];
+				break;
+			}
+		}
+
+		self::assertSame( 'New notes', $content_write );
+	}
+}

--- a/tests/Unit/Admin/BookmarkMetaboxTest.php
+++ b/tests/Unit/Admin/BookmarkMetaboxTest.php
@@ -7,8 +7,10 @@ namespace Apermo\LinkStash\Tests\Unit\Admin;
 use Apermo\LinkStash\Admin\BookmarkMetabox;
 use Apermo\LinkStash\PostType\BookmarkMeta;
 use Apermo\LinkStash\PostType\BookmarkPostType;
+use Apermo\LinkStash\Url\MetadataFetcher;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
+use Mockery;
 use PHPUnit\Framework\TestCase;
 use WP_Post;
 
@@ -109,7 +111,7 @@ class BookmarkMetaboxTest extends TestCase {
 	 * @return void
 	 */
 	public function test_register_hooks_admin_actions(): void {
-		$metabox = new BookmarkMetabox();
+		$metabox = $this->metabox();
 		$metabox->register();
 
 		$post_type = BookmarkPostType::POST_TYPE;
@@ -124,7 +126,7 @@ class BookmarkMetaboxTest extends TestCase {
 	 * @return void
 	 */
 	public function test_disable_block_editor_only_for_bookmark_cpt(): void {
-		$metabox = new BookmarkMetabox();
+		$metabox = $this->metabox();
 
 		self::assertFalse( $metabox->disable_block_editor( true, BookmarkPostType::POST_TYPE ) );
 		self::assertTrue( $metabox->disable_block_editor( true, 'post' ) );
@@ -139,7 +141,7 @@ class BookmarkMetaboxTest extends TestCase {
 	public function test_register_meta_boxes(): void {
 		Functions\expect( 'add_meta_box' )->twice();
 
-		( new BookmarkMetabox() )->register_meta_boxes();
+		$this->metabox()->register_meta_boxes();
 	}
 
 	/**
@@ -161,7 +163,7 @@ class BookmarkMetaboxTest extends TestCase {
 		$post->ID = 7;
 
 		\ob_start();
-		( new BookmarkMetabox() )->render_url_meta_box( $post );
+		$this->metabox()->render_url_meta_box( $post );
 		$output = (string) \ob_get_clean();
 
 		self::assertStringContainsString( 'name="linkstash_url"', $output );
@@ -181,7 +183,7 @@ class BookmarkMetaboxTest extends TestCase {
 		$post->post_content = 'These are my notes.';
 
 		\ob_start();
-		( new BookmarkMetabox() )->render_note_meta_box( $post );
+		$this->metabox()->render_note_meta_box( $post );
 		$output = (string) \ob_get_clean();
 
 		self::assertStringContainsString( '<textarea', $output );
@@ -197,7 +199,7 @@ class BookmarkMetaboxTest extends TestCase {
 		$post     = new WP_Post();
 		$post->ID = 7;
 
-		( new BookmarkMetabox() )->save_post( 7, $post );
+		$this->metabox()->save_post( 7, $post );
 
 		self::assertSame( [], $this->meta_writes );
 		self::assertSame( [], $this->post_writes );
@@ -220,7 +222,7 @@ class BookmarkMetaboxTest extends TestCase {
 		$post->post_title   = 'My title';
 		$post->post_content = '';
 
-		( new BookmarkMetabox() )->save_post( 7, $post );
+		$this->metabox()->save_post( 7, $post );
 
 		$keys = \array_column( $this->meta_writes, 1 );
 		self::assertContains( BookmarkMeta::META_URL, $keys );
@@ -252,7 +254,7 @@ class BookmarkMetaboxTest extends TestCase {
 		$post->post_title   = '';
 		$post->post_content = '';
 
-		( new BookmarkMetabox() )->save_post( 7, $post );
+		$this->metabox()->save_post( 7, $post );
 
 		$title_write = null;
 		foreach ( $this->post_writes as $write ) {
@@ -282,7 +284,7 @@ class BookmarkMetaboxTest extends TestCase {
 		$post->post_title   = 'T';
 		$post->post_content = 'Old notes';
 
-		( new BookmarkMetabox() )->save_post( 7, $post );
+		$this->metabox()->save_post( 7, $post );
 
 		$content_write = null;
 		foreach ( $this->post_writes as $write ) {
@@ -293,5 +295,25 @@ class BookmarkMetaboxTest extends TestCase {
 		}
 
 		self::assertSame( 'New notes', $content_write );
+	}
+
+	/**
+	 * Builds a metabox wired to a Mockery'd metadata fetcher that reports
+	 * unreachable. The fetcher only runs when the URL changes during save,
+	 * so most tests don't actually invoke it.
+	 *
+	 * @return BookmarkMetabox
+	 */
+	private function metabox(): BookmarkMetabox {
+		$fetcher = Mockery::mock( MetadataFetcher::class );
+		$fetcher->shouldReceive( 'fetch' )->andReturn(
+			[
+				'title'       => null,
+				'description' => null,
+				'reachable'   => false,
+			],
+		);
+
+		return new BookmarkMetabox( $fetcher );
 	}
 }

--- a/tests/Unit/Admin/DashboardWidgetTest.php
+++ b/tests/Unit/Admin/DashboardWidgetTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\LinkStash\Tests\Unit\Admin;
+
+use Apermo\LinkStash\Admin\DashboardWidget;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the dashboard "Quick Bookmark" widget.
+ */
+class DashboardWidgetTest extends TestCase {
+
+	/**
+	 * Sets up Brain Monkey with output-friendly stubs.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'esc_html__' )->returnArg();
+		Functions\when( 'esc_attr' )->returnArg();
+		Functions\when( 'esc_url' )->returnArg();
+		Functions\when( 'esc_attr_e' )->alias(
+			static function ( $value ): void {
+				echo $value; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- test stub.
+			},
+		);
+		Functions\when( 'esc_html_e' )->alias(
+			static function ( $value ): void {
+				echo $value; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- test stub.
+			},
+		);
+		Functions\when( 'admin_url' )->alias( static fn ( string $path ): string => 'https://wp.example.tld/wp-admin/' . $path );
+		Functions\when( 'wp_create_nonce' )->justReturn( 'nonce-value' );
+	}
+
+	/**
+	 * Tears down Brain Monkey.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Verifies register hooks wp_dashboard_setup.
+	 *
+	 * @return void
+	 */
+	public function test_register_hooks_dashboard_setup(): void {
+		$widget = new DashboardWidget();
+		$widget->register();
+
+		self::assertNotFalse( has_action( 'wp_dashboard_setup', [ $widget, 'register_widget' ] ) );
+	}
+
+	/**
+	 * Verifies the widget is added when the user can edit posts.
+	 *
+	 * @return void
+	 */
+	public function test_register_widget_calls_wp_add_dashboard_widget(): void {
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\expect( 'wp_add_dashboard_widget' )->once();
+
+		( new DashboardWidget() )->register_widget();
+	}
+
+	/**
+	 * Verifies the widget is suppressed when the user lacks edit_posts.
+	 *
+	 * @return void
+	 */
+	public function test_register_widget_suppressed_without_cap(): void {
+		Functions\when( 'current_user_can' )->justReturn( false );
+		Functions\expect( 'wp_add_dashboard_widget' )->never();
+
+		( new DashboardWidget() )->register_widget();
+	}
+
+	/**
+	 * Verifies render outputs the form via the shared QuickAdd helper.
+	 *
+	 * @return void
+	 */
+	public function test_render_outputs_form(): void {
+		\ob_start();
+		( new DashboardWidget() )->render();
+		$output = (string) \ob_get_clean();
+
+		self::assertStringContainsString( 'linkstash-dashboard-widget', $output );
+		self::assertStringContainsString( 'name="url"', $output );
+		self::assertStringContainsString( 'name="tags"', $output );
+		self::assertStringContainsString( 'name="public"', $output );
+	}
+}

--- a/tests/Unit/Admin/TagAutocompleteTest.php
+++ b/tests/Unit/Admin/TagAutocompleteTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\LinkStash\Tests\Unit\Admin;
+
+use Apermo\LinkStash\Admin\TagAutocomplete;
+use Apermo\LinkStash\PostType\BookmarkPostType;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use WP_Screen;
+
+/**
+ * Tests the tag autocomplete enqueue.
+ */
+class TagAutocompleteTest extends TestCase {
+
+	/**
+	 * Sets up Brain Monkey.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	/**
+	 * Tears down Brain Monkey.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Verifies register hooks admin_enqueue_scripts.
+	 *
+	 * @return void
+	 */
+	public function test_register_hooks_enqueue(): void {
+		$widget = new TagAutocomplete();
+		$widget->register();
+
+		self::assertNotFalse( has_action( 'admin_enqueue_scripts', [ $widget, 'maybe_enqueue' ] ) );
+	}
+
+	/**
+	 * Verifies the dashboard hook (`index.php`) enqueues the script.
+	 *
+	 * @return void
+	 */
+	public function test_enqueues_on_dashboard(): void {
+		Functions\expect( 'wp_enqueue_script' )->once()->with( 'jquery-ui-autocomplete' );
+		Functions\when( 'wp_register_style' )->justReturn( true );
+		Functions\when( 'wp_enqueue_style' )->justReturn();
+		Functions\when( 'wp_add_inline_script' )->justReturn( true );
+		Functions\when( 'wp_add_inline_style' )->justReturn( true );
+
+		( new TagAutocomplete() )->maybe_enqueue( 'index.php' );
+	}
+
+	/**
+	 * Verifies the bookmark list-screen enqueues the script.
+	 *
+	 * @return void
+	 */
+	public function test_enqueues_on_bookmark_list(): void {
+		$screen            = new WP_Screen();
+		$screen->base      = 'edit';
+		$screen->post_type = BookmarkPostType::POST_TYPE;
+		Functions\when( 'get_current_screen' )->justReturn( $screen );
+
+		Functions\expect( 'wp_enqueue_script' )->once();
+		Functions\when( 'wp_register_style' )->justReturn( true );
+		Functions\when( 'wp_enqueue_style' )->justReturn();
+		Functions\when( 'wp_add_inline_script' )->justReturn( true );
+		Functions\when( 'wp_add_inline_style' )->justReturn( true );
+
+		( new TagAutocomplete() )->maybe_enqueue( 'edit.php' );
+	}
+
+	/**
+	 * Verifies it skips an unrelated screen.
+	 *
+	 * @return void
+	 */
+	public function test_skips_other_screens(): void {
+		Functions\expect( 'wp_enqueue_script' )->never();
+
+		( new TagAutocomplete() )->maybe_enqueue( 'plugins.php' );
+	}
+
+	/**
+	 * Verifies it skips edit.php for unrelated post types.
+	 *
+	 * @return void
+	 */
+	public function test_skips_edit_for_other_cpts(): void {
+		$screen            = new WP_Screen();
+		$screen->base      = 'edit';
+		$screen->post_type = 'post';
+		Functions\when( 'get_current_screen' )->justReturn( $screen );
+
+		Functions\expect( 'wp_enqueue_script' )->never();
+
+		( new TagAutocomplete() )->maybe_enqueue( 'edit.php' );
+	}
+}

--- a/tests/Unit/Admin/UrlAutoSchemeTest.php
+++ b/tests/Unit/Admin/UrlAutoSchemeTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\LinkStash\Tests\Unit\Admin;
+
+use Apermo\LinkStash\Admin\UrlAutoScheme;
+use Apermo\LinkStash\PostType\BookmarkPostType;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use WP_Screen;
+
+/**
+ * Tests the auto-prepend-https url-input enhancer.
+ */
+class UrlAutoSchemeTest extends TestCase {
+
+	/**
+	 * Sets up Brain Monkey.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	/**
+	 * Tears down Brain Monkey.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Verifies register hooks admin_enqueue_scripts.
+	 *
+	 * @return void
+	 */
+	public function test_register_hooks_enqueue(): void {
+		$enhancer = new UrlAutoScheme();
+		$enhancer->register();
+
+		self::assertNotFalse( has_action( 'admin_enqueue_scripts', [ $enhancer, 'maybe_enqueue' ] ) );
+	}
+
+	/**
+	 * Verifies the dashboard hook enqueues the inline script.
+	 *
+	 * @return void
+	 */
+	public function test_enqueues_on_dashboard(): void {
+		Functions\when( 'wp_register_script' )->justReturn( true );
+		Functions\expect( 'wp_enqueue_script' )->once()->with( 'linkstash-url-auto-scheme' );
+		Functions\when( 'wp_add_inline_script' )->justReturn( true );
+
+		( new UrlAutoScheme() )->maybe_enqueue( 'index.php' );
+	}
+
+	/**
+	 * Verifies the bookmark edit screen enqueues the script.
+	 *
+	 * @return void
+	 */
+	public function test_enqueues_on_bookmark_edit_screen(): void {
+		$screen            = new WP_Screen();
+		$screen->base      = 'post';
+		$screen->post_type = BookmarkPostType::POST_TYPE;
+		Functions\when( 'get_current_screen' )->justReturn( $screen );
+
+		Functions\when( 'wp_register_script' )->justReturn( true );
+		Functions\expect( 'wp_enqueue_script' )->once();
+		Functions\when( 'wp_add_inline_script' )->justReturn( true );
+
+		( new UrlAutoScheme() )->maybe_enqueue( 'post.php' );
+	}
+
+	/**
+	 * Verifies unrelated screens are skipped.
+	 *
+	 * @return void
+	 */
+	public function test_skips_unrelated_screens(): void {
+		Functions\expect( 'wp_enqueue_script' )->never();
+
+		( new UrlAutoScheme() )->maybe_enqueue( 'plugins.php' );
+	}
+
+	/**
+	 * Verifies post.php for an unrelated CPT is skipped.
+	 *
+	 * @return void
+	 */
+	public function test_skips_post_screen_for_other_cpts(): void {
+		$screen            = new WP_Screen();
+		$screen->base      = 'post';
+		$screen->post_type = 'page';
+		Functions\when( 'get_current_screen' )->justReturn( $screen );
+
+		Functions\expect( 'wp_enqueue_script' )->never();
+
+		( new UrlAutoScheme() )->maybe_enqueue( 'post.php' );
+	}
+}

--- a/tests/Unit/PostType/BookmarkMetaTest.php
+++ b/tests/Unit/PostType/BookmarkMetaTest.php
@@ -55,7 +55,7 @@ class BookmarkMetaTest extends TestCase {
 	 */
 	public function test_register_post_meta_registers_all_keys(): void {
 		Functions\expect( 'register_post_meta' )
-			->times( 4 )
+			->times( 5 )
 			->with( BookmarkPostType::POST_TYPE, Mockery::type( 'string' ), Mockery::type( 'array' ) );
 
 		( new BookmarkMeta() )->register_post_meta();

--- a/tests/Unit/PostType/BookmarkPostTypeTest.php
+++ b/tests/Unit/PostType/BookmarkPostTypeTest.php
@@ -29,7 +29,7 @@ class BookmarkPostTypeTest extends TestCase {
 			&& $args['show_in_rest'] === true
 			&& $args['rest_base'] === 'bookmarks'
 			&& $args['capability_type'] === 'post'
-			&& $args['supports'] === [ 'title', 'editor', 'custom-fields' ]
+			&& $args['supports'] === [ 'title' ]
 			&& $args['has_archive'] === false
 			&& $args['hierarchical'] === false;
 	}

--- a/tests/Unit/Url/DisplayUrlTest.php
+++ b/tests/Unit/Url/DisplayUrlTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\LinkStash\Tests\Unit\Url;
+
+use Apermo\LinkStash\Url\DisplayUrl;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the human-readable URL helper used as a title fallback.
+ */
+class DisplayUrlTest extends TestCase {
+
+	/**
+	 * Provides input/output pairs for simplify().
+	 *
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public static function urlProvider(): array {
+		return [
+			'strip scheme + www, drop trailing slash' => [
+				'https://www.example.tld/blog/article?utm=1#x',
+				'example.tld/blog/article',
+			],
+			'root with trailing slash'                => [ 'https://example.tld/', 'example.tld' ],
+			'root without trailing slash'             => [ 'https://example.tld', 'example.tld' ],
+			'http scheme + path with query stripped'  => [
+				'http://Example.tld/x/y?a=1',
+				'example.tld/x/y',
+			],
+			'plain hostname keeps deep path'          => [
+				'https://blog.example.tld/2026/01/foo/',
+				'blog.example.tld/2026/01/foo',
+			],
+			'unparseable returns input unchanged'     => [ 'not a url', 'not a url' ],
+			'empty string'                            => [ '', '' ],
+		];
+	}
+
+	/**
+	 * Sets up Brain Monkey and stubs wp_parse_url with PHP's parse_url.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+		// Stubbing wp_parse_url with PHP's parse_url is the whole point of
+		// this alias — the suggested wp_parse_url alternative is what the
+		// stub itself is replacing.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
+		Functions\when( 'wp_parse_url' )->alias( static fn ( string $url ) => \parse_url( $url ) );
+	}
+
+	/**
+	 * Tears down Brain Monkey.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Verifies simplify produces the expected display string for each input.
+	 *
+	 * @param string $input    URL input.
+	 * @param string $expected Expected display value.
+	 *
+	 * @return void
+	 */
+	#[DataProvider( 'urlProvider' )]
+	public function test_simplify( string $input, string $expected ): void {
+		self::assertSame( $expected, DisplayUrl::simplify( $input ) );
+	}
+}


### PR DESCRIPTION
## Summary

The default Gutenberg edit screen for `linkstash_bookmark` is overkill — there's no URL field, you have to dig into Custom Fields. This PR replaces it with a small classic-editor form whose fields map 1:1 to the data model.

| UI field | Persists as |
|---|---|
| URL | `_linkstash_url` (+ `_linkstash_url_canonical`) |
| Label | `post_title` (falls back to a simplified URL) |
| Note | `post_content` (plain `<textarea>`, no TinyMCE) |
| Tags | `linkstash_tag` taxonomy (existing meta box) |
| Visibility | `post_status` (existing publish meta box) |
| Unread / Archived | `_linkstash_unread`, `_linkstash_archived` (checkboxes in the URL meta box) |

- Block editor opted out for the bookmark CPT only (`use_block_editor_for_post_type` filter).
- CPT `supports` shrinks to `['title']`; the `'editor'` and `'custom-fields'` panels are gone.
- New `Apermo\LinkStash\Url\DisplayUrl::simplify()` helper drives the title fallback (`example.tld/article` style — distinct from `Canonicalizer`, which preserves dedupe identity).
- Save handler in `Apermo\LinkStash\Admin\BookmarkMetabox` validates the nonce, bails on autosave / revisions / cap misses, then persists URL + canonical + flags + notes, and writes a fallback title only when the user left it blank.

## Test plan

- [x] `composer cs && composer analyse && composer test:unit` — 131 tests / 201 assertions / 86.13% line coverage
- [x] DDEV smoke: Add New Bookmark → save with no label → list shows the simplified URL; save with a label → label wins; toggling Unread / Archived persists; visibility flips between public/private via the Publish meta box
- [ ] Hit `/wp-json/linkstash/v1/bookmarks/{id}` for a bookmark just edited via the new screen → fields match