### PR TITLE
release: v0.1.2 — output-escaping hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-05-03
+
+### Security
+
+- Tighter output escaping in the bookmark list-table column headers
+  (`src/Admin/ListColumns.php`) and the contextual help tabs
+  (`src/Admin/HelpTabs.php`). Every translatable string that lands in
+  HTML now goes through `esc_html__()` at the call site, and the two
+  `sprintf`-builds-help-text spots that previously ran `wp_kses` on
+  the translation template *before* interpolation now wrap the
+  interpolated result, so the embedded `<a>` / `<code>` / `<strong>`
+  fragments pass through the same allow-list. None of the values
+  involved are user-supplied today, so no exploitable flaw existed in
+  0.1.1, but the patterns were fragile and `WP_List_Table` writes
+  column headers to the page raw — flagged in code review and fixed
+  here as defense in depth.
+
 ## [0.1.1] - 2026-05-02
 
 ### Added

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: LinkStash
  * Plugin URI:  https://github.com/apermo/linkstash
  * Description: A self-hosted bookmark collection with a token-protected REST API.
- * Version:     0.1.1
+ * Version:     0.1.2
  * Author:      Christoph Daum
  * Author URI:  https://apermo.de
  * License:     GPL-2.0-or-later

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: bookmarks, links, rest-api, self-hosted, archive
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.1
-Stable tag: 0.1.1
+Stable tag: 0.1.2
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -165,6 +165,10 @@ defense-in-depth narrowing of the CORS surface.
 5. Companion Chrome extension popup saving the current tab.
 
 == Changelog ==
+
+= 0.1.2 =
+* Hardening: tighter output escaping in the bookmark list table and
+  contextual help tabs. No functional changes.
 
 = 0.1.1 =
 * New: single Favorite flag (replaces Unread / Archived), with a

--- a/src/Admin/HelpTabs.php
+++ b/src/Admin/HelpTabs.php
@@ -72,14 +72,17 @@ class HelpTabs {
 				__( '<strong>Browser extension</strong> — see the next tab.', 'linkstash' ),
 				[ 'strong' => [] ],
 			) . '</li>'
-			. '<li>' . \sprintf(
-				wp_kses(
+			. '<li>' . wp_kses(
+				\sprintf(
 					/* translators: 1: REST endpoint, 2: Settings page label. */
 					__( '<strong>REST API</strong> — POST to %1$s with an Authorization Bearer token generated under %2$s.', 'linkstash' ),
-					[ 'strong' => [] ],
+					'<code>/wp-json/linkstash/v1/bookmarks</code>',
+					'<strong>' . esc_html__( 'Settings → LinkStash', 'linkstash' ) . '</strong>',
 				),
-				'<code>/wp-json/linkstash/v1/bookmarks</code>',
-				'<strong>' . esc_html__( 'Settings → LinkStash', 'linkstash' ) . '</strong>',
+				[
+					'strong' => [],
+					'code'   => [],
+				],
 			) . '</li>'
 			. '</ul>'
 			. '<p>' . esc_html__( 'LinkStash dedupes by canonical URL: saving the same page twice updates the existing record instead of creating a duplicate. The X-LinkStash-Existing response header on a re-save tells API clients which path was taken.', 'linkstash' ) . '</p>';
@@ -93,10 +96,19 @@ class HelpTabs {
 	private static function extension_html(): string {
 		$repo_url = 'https://github.com/apermo/linkstash-extension';
 
-		return '<p>' . \sprintf(
-			/* translators: %s: linked repo URL. */
-			esc_html__( 'A companion Chrome extension is currently under review at the Chrome Web Store. Once it is approved you will be able to install it directly from the store; until then you can install it from source by following the instructions in the repository at %s.', 'linkstash' ),
-			'<a href="' . esc_url( $repo_url ) . '" target="_blank" rel="noopener">' . esc_html( $repo_url ) . '</a>',
+		return '<p>' . wp_kses(
+			\sprintf(
+				/* translators: %s: linked repo URL. */
+				esc_html__( 'A companion Chrome extension is currently under review at the Chrome Web Store. Once it is approved you will be able to install it directly from the store; until then you can install it from source by following the instructions in the repository at %s.', 'linkstash' ),
+				'<a href="' . esc_url( $repo_url ) . '" target="_blank" rel="noopener">' . esc_html( $repo_url ) . '</a>',
+			),
+			[
+				'a' => [
+					'href'   => [],
+					'target' => [],
+					'rel'    => [],
+				],
+			],
 		) . '</p>'
 			. '<p>' . esc_html__( 'Once installed, the extension adds:', 'linkstash' ) . '</p>'
 			. '<ul>'
@@ -105,10 +117,13 @@ class HelpTabs {
 			. '<li>' . esc_html__( 'An edit-from-popup flow with title, description, tags, and a public/private toggle.', 'linkstash' ) . '</li>'
 			. '<li>' . esc_html__( 'A right-click "Save link to LinkStash" context-menu entry, so you can save a link without visiting it.', 'linkstash' ) . '</li>'
 			. '</ul>'
-			. '<p>' . \sprintf(
-				/* translators: %s: Settings page label. */
-				esc_html__( 'After installing, open the extension\'s options page, enter your site URL and a Bearer token generated under %s, and pick your default visibility.', 'linkstash' ),
-				'<strong>' . esc_html__( 'Settings → LinkStash', 'linkstash' ) . '</strong>',
+			. '<p>' . wp_kses(
+				\sprintf(
+					/* translators: %s: Settings page label. */
+					esc_html__( 'After installing, open the extension\'s options page, enter your site URL and a Bearer token generated under %s, and pick your default visibility.', 'linkstash' ),
+					'<strong>' . esc_html__( 'Settings → LinkStash', 'linkstash' ) . '</strong>',
+				),
+				[ 'strong' => [] ],
 			) . '</p>';
 	}
 
@@ -158,7 +173,7 @@ class HelpTabs {
 		$screen->add_help_tab(
 			[
 				'id'      => 'linkstash-overview',
-				'title'   => __( 'Overview', 'linkstash' ),
+				'title'   => esc_html__( 'Overview', 'linkstash' ),
 				'content' => self::overview_html(),
 			],
 		);
@@ -166,7 +181,7 @@ class HelpTabs {
 		$screen->add_help_tab(
 			[
 				'id'      => 'linkstash-add-bookmarks',
-				'title'   => __( 'Adding bookmarks', 'linkstash' ),
+				'title'   => esc_html__( 'Adding bookmarks', 'linkstash' ),
 				'content' => self::add_bookmarks_html(),
 			],
 		);
@@ -174,7 +189,7 @@ class HelpTabs {
 		$screen->add_help_tab(
 			[
 				'id'      => 'linkstash-extension',
-				'title'   => __( 'Browser extension', 'linkstash' ),
+				'title'   => esc_html__( 'Browser extension', 'linkstash' ),
 				'content' => self::extension_html(),
 			],
 		);

--- a/src/Admin/ListColumns.php
+++ b/src/Admin/ListColumns.php
@@ -122,12 +122,12 @@ class ListColumns {
 	public function filter_columns( array $columns ): array {
 		return [
 			'cb'            => $columns['cb'] ?? '<input type="checkbox" />',
-			'title'         => __( 'Title', 'linkstash' ),
-			'url'           => __( 'URL', 'linkstash' ),
-			'linkstash_tag' => __( 'Tags', 'linkstash' ),
-			'visibility'    => __( 'Visibility', 'linkstash' ),
-			'favorite'      => __( 'Favorite', 'linkstash' ),
-			'date'          => $columns['date'] ?? __( 'Date', 'linkstash' ),
+			'title'         => esc_html__( 'Title', 'linkstash' ),
+			'url'           => esc_html__( 'URL', 'linkstash' ),
+			'linkstash_tag' => esc_html__( 'Tags', 'linkstash' ),
+			'visibility'    => esc_html__( 'Visibility', 'linkstash' ),
+			'favorite'      => esc_html__( 'Favorite', 'linkstash' ),
+			'date'          => $columns['date'] ?? esc_html__( 'Date', 'linkstash' ),
 		];
 	}
 

--- a/src/Main.php
+++ b/src/Main.php
@@ -33,7 +33,7 @@ use Apermo\LinkStash\Url\MetadataFetcher;
  */
 class Main {
 
-	public const VERSION = '0.1.1';
+	public const VERSION = '0.1.2';
 
 	private const STARTER_TAGS_SEEDED_OPTION = 'linkstash_starter_tags_seeded';
 


### PR DESCRIPTION
## Summary

Patch release rolling up the output-escaping hardening flagged in #38. No functional changes; safe to merge and ship to wp.org as 0.1.2 instead of 0.1.1.

Closes #38.

## What changed

- **`HelpTabs::add_bookmarks_html` / `extension_html`** — three `sprintf`-builds-help-text spots were running `wp_kses` on the translation template *before* `sprintf` interpolated `<code>` / `<a>` / `<strong>` arguments, so the embedded HTML never went through the kses allow-list. Now wraps the interpolated result.
- **`HelpTabs::maybe_add_help_tabs`** — three help-tab titles use `esc_html__()` at the call site instead of `__()`. WP core does escape these downstream, but the project convention is escape-on-output.
- **`ListColumns::filter_columns`** — six list-table column headers switched to `esc_html__()`. `WP_List_Table::print_column_headers()` writes column names raw to the page, so this one is not redundant — it's the actual escape point.

No exploitable flaw existed in 0.1.1: every interpolated value is a constant or another translated string. These are defense-in-depth fixes Gemini flagged in PR #37 review.

## Verification

- Unit + integration tests still green (174/272 locally).
- PHPCS + PHPStan clean.
- Manual smoke: bookmark list table renders identically; help tabs render identically.