### PR TITLE
release: v0.1.3 — fix Chrome extension save flow

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,54 @@
+# wp.org plugin-directory bundle exclusions.
+#
+# Used by 10up/action-wordpress-plugin-deploy (called from
+# .github/workflows/wporg-deploy.yml) to decide what stays out of the
+# released ZIP and the SVN trunk. Mirrors the export-ignore entries in
+# .gitattributes so a local `git archive` produces the same shape.
+#
+# What ships:
+#   plugin.php uninstall.php LICENSE readme.txt
+#   composer.json (so the runtime vendor/ has provenance)
+#   src/ assets/ vendor/
+
+# Local + CI tooling
+/.ddev
+/.editorconfig
+/.gemini
+/.github
+/.husky
+/.gitattributes
+/.gitignore
+/.lintstagedrc.js
+/.lighthouserc.js
+/.phpunit.cache
+/.wp-env.json
+/.distignore
+
+# Source bundles + dev artifacts
+/branding
+/.wordpress-org
+/setup.sh
+
+# Tests + analyser configs
+/e2e
+/tests
+/phpcs.xml.dist
+/phpstan.neon.dist
+/phpunit.xml.dist
+/playwright.config.js
+/wp-tests-config.php.dist
+
+# Node + JS toolchain (we ship vanilla JS, no build step)
+/package.json
+/package-lock.json
+
+# Misc dev-facing docs + CI metadata
+/codecov.yml
+/CHANGELOG.md
+/CLAUDE.md
+/README.md
+
+# Composer dev metadata: composer.json stays (Plugin Check requires
+# the file when /vendor is present), composer.lock is large and only
+# useful at install/regen time.
+/composer.lock

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,26 +1,37 @@
+# Exclusions for `git archive` — kept in sync with .distignore so a
+# local archive produces the same shape as 10up's wporg-deploy action.
+
 /.ddev/             export-ignore
 /.editorconfig      export-ignore
 /.gemini/           export-ignore
 /.github/           export-ignore
-/.wordpress-org/    export-ignore
-/branding/          export-ignore
 /.husky/            export-ignore
+/.wordpress-org/    export-ignore
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
 /.lintstagedrc.js   export-ignore
+/.lighthouserc.js   export-ignore
 /.phpunit.cache/    export-ignore
+/.wp-env.json       export-ignore
+/.distignore        export-ignore
+
+/branding/          export-ignore
 /setup.sh           export-ignore
+
+/e2e/               export-ignore
 /tests/             export-ignore
 /phpcs.xml.dist     export-ignore
 /phpstan.neon.dist  export-ignore
 /phpunit.xml.dist   export-ignore
+/playwright.config.js     export-ignore
 /wp-tests-config.php.dist export-ignore
-/e2e/               export-ignore
-/playwright.config.js export-ignore
+
 /package.json       export-ignore
-/.lighthouserc.js   export-ignore
-/.wp-env.json       export-ignore
 /package-lock.json  export-ignore
+
 /codecov.yml        export-ignore
 CHANGELOG.md        export-ignore
 CLAUDE.md           export-ignore
+README.md           export-ignore
+
+/composer.lock      export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-05-03
+
+### Fixed
+
+- Chrome-extension save flow on production hosts. WordPress core's
+  `rest_send_cors_headers` runs `sanitize_url()` on the incoming
+  `Origin` header, and `chrome-extension://...` is not in
+  `wp_allowed_protocols()` — so core writes an empty
+  `Access-Control-Allow-Origin:` value. Browsers reject the empty
+  string, the extension's preflight fails, and the POST silently
+  never runs. (Local dev with DDEV typically didn't reproduce because
+  the LiteSpeed/Apache plugin order on production let core's hook
+  fire after ours and overwrite the value; on a barebones WP it was
+  still a latent bug because core would always overwrite the origin
+  on direct POSTs.) `CorsHandler::send_cors_headers` now removes the
+  core hook for LinkStash routes when the origin matches the
+  allow-list, and emits the complete CORS header set itself
+  (`Access-Control-Allow-Origin`, `-Allow-Methods`, `-Allow-Headers`,
+  `-Allow-Credentials`, `-Expose-Headers`, `Vary`). Other namespaces
+  and disallowed origins still flow through core.
+
 ## [0.1.2] - 2026-05-03
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`Access-Control-Allow-Origin`, `-Allow-Methods`, `-Allow-Headers`,
   `-Allow-Credentials`, `-Expose-Headers`, `Vary`). Other namespaces
   and disallowed origins still flow through core.
+- Plugin Check `PluginCheck.Security.DirectDB.UnescapedDBParameter`
+  warning on the `/tags` aggregate query in `TagsController`. The
+  query was already correctly prepared (every interpolated value is
+  a `$wpdb->`-prefixed table name or a constant `%s`/`%d` placeholder
+  built in `build_where_clause`) and the WordPress.DB sniff variants
+  were already suppressed; Plugin Check ships its own scanner under
+  the `PluginCheck.*` namespace that doesn't inherit the existing
+  ignore list, so the same false positive is now suppressed
+  alongside the WordPress.DB ones.
 
 ## [0.1.2] - 2026-05-03
 

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: LinkStash
  * Plugin URI:  https://github.com/apermo/linkstash
  * Description: A self-hosted bookmark collection with a token-protected REST API.
- * Version:     0.1.2
+ * Version:     0.1.3
  * Author:      Christoph Daum
  * Author URI:  https://apermo.de
  * License:     GPL-2.0-or-later

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: bookmarks, links, rest-api, self-hosted, archive
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.1
-Stable tag: 0.1.2
+Stable tag: 0.1.3
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -165,6 +165,15 @@ defense-in-depth narrowing of the CORS surface.
 5. Companion Chrome extension popup saving the current tab.
 
 == Changelog ==
+
+= 0.1.3 =
+* Fixed: the Chrome extension's save flow now actually reaches the
+  REST API on production hosts. WordPress core's CORS handler strips
+  `chrome-extension://` origins (the scheme is not in
+  `wp_allowed_protocols()`) and emits an empty
+  `Access-Control-Allow-Origin` header, which browsers reject. The
+  plugin now removes the core hook for LinkStash routes and emits a
+  complete CORS header set itself.
 
 = 0.1.2 =
 * Hardening: tighter output escaping in the bookmark list table and

--- a/readme.txt
+++ b/readme.txt
@@ -16,7 +16,7 @@ companion Chrome extension.
 LinkStash turns your WordPress site into a personal bookmark archive,
 inspired by linkding and Delicious. Save URLs with a title,
 notes, and tags from the WordPress admin or from your browser via a
-[Chrome extension](https://github.com/apermo/linkstash-extension); read
+[Chrome extension](https://chromewebstore.google.com/detail/linkstash/midebpgblmgkcgljcgojjbehnonljnmk); read
 them back through the same admin UI or over a REST API designed for
 extensions and your own scripts.
 
@@ -69,8 +69,11 @@ recoverable.
 
 = Companion Chrome extension =
 
-A Chrome MV3 extension is in development at
-[apermo/linkstash-extension](https://github.com/apermo/linkstash-extension).
+A Chrome MV3 extension is published on the Chrome Web Store:
+https://chromewebstore.google.com/detail/linkstash/midebpgblmgkcgljcgojjbehnonljnmk
+
+Source: [apermo/linkstash-extension](https://github.com/apermo/linkstash-extension).
+
 It surfaces the saved/unsaved state on the action badge, lets you save
 or edit the current tab from the popup, and offers a right-click
 "Save link" context menu.

--- a/src/Admin/HelpTabs.php
+++ b/src/Admin/HelpTabs.php
@@ -19,7 +19,10 @@ use WP_Screen;
  */
 class HelpTabs {
 
-	private const SCREEN_ID = 'edit-' . BookmarkPostType::POST_TYPE;
+	private const SCREEN_ID           = 'edit-' . BookmarkPostType::POST_TYPE;
+	private const PLUGIN_REPO_URL     = 'https://github.com/apermo/linkstash';
+	private const EXTENSION_STORE_URL = 'https://chromewebstore.google.com/detail/linkstash/midebpgblmgkcgljcgojjbehnonljnmk';
+	private const EXTENSION_REPO_URL  = 'https://github.com/apermo/linkstash-extension';
 
 	/**
 	 * Returns the Overview tab markup.
@@ -94,21 +97,27 @@ class HelpTabs {
 	 * @return string
 	 */
 	private static function extension_html(): string {
-		$repo_url = 'https://github.com/apermo/linkstash-extension';
+		$store_link = '<a href="' . esc_url( self::EXTENSION_STORE_URL ) . '" target="_blank" rel="noopener">'
+			. esc_html__( 'Chrome Web Store', 'linkstash' ) . '</a>';
+		$repo_link  = '<a href="' . esc_url( self::EXTENSION_REPO_URL ) . '" target="_blank" rel="noopener">'
+			. esc_html( self::EXTENSION_REPO_URL ) . '</a>';
+
+		$kses_a = [
+			'a' => [
+				'href'   => [],
+				'target' => [],
+				'rel'    => [],
+			],
+		];
 
 		return '<p>' . wp_kses(
 			\sprintf(
-				/* translators: %s: linked repo URL. */
-				esc_html__( 'A companion Chrome extension is currently under review at the Chrome Web Store. Once it is approved you will be able to install it directly from the store; until then you can install it from source by following the instructions in the repository at %s.', 'linkstash' ),
-				'<a href="' . esc_url( $repo_url ) . '" target="_blank" rel="noopener">' . esc_html( $repo_url ) . '</a>',
+				/* translators: 1: Chrome Web Store link, 2: GitHub source link. */
+				esc_html__( 'A companion Chrome extension is available on the %1$s. The source is at %2$s if you prefer to review it or install from source.', 'linkstash' ),
+				$store_link,
+				$repo_link,
 			),
-			[
-				'a' => [
-					'href'   => [],
-					'target' => [],
-					'rel'    => [],
-				],
-			],
+			$kses_a,
 		) . '</p>'
 			. '<p>' . esc_html__( 'Once installed, the extension adds:', 'linkstash' ) . '</p>'
 			. '<ul>'
@@ -136,10 +145,10 @@ class HelpTabs {
 		$settings_url = admin_url( 'options-general.php?page=linkstash' );
 
 		return '<p><strong>' . esc_html__( 'For more information:', 'linkstash' ) . '</strong></p>'
-			. '<p><a href="https://github.com/apermo/linkstash" target="_blank" rel="noopener">'
+			. '<p><a href="' . esc_url( self::PLUGIN_REPO_URL ) . '" target="_blank" rel="noopener">'
 			. esc_html__( 'Plugin source &amp; README', 'linkstash' )
 			. '</a></p>'
-			. '<p><a href="https://github.com/apermo/linkstash-extension" target="_blank" rel="noopener">'
+			. '<p><a href="' . esc_url( self::EXTENSION_STORE_URL ) . '" target="_blank" rel="noopener">'
 			. esc_html__( 'Chrome extension', 'linkstash' )
 			. '</a></p>'
 			. '<p><a href="' . esc_url( $settings_url ) . '">'

--- a/src/Main.php
+++ b/src/Main.php
@@ -33,7 +33,7 @@ use Apermo\LinkStash\Url\MetadataFetcher;
  */
 class Main {
 
-	public const VERSION = '0.1.2';
+	public const VERSION = '0.1.3';
 
 	private const STARTER_TAGS_SEEDED_OPTION = 'linkstash_starter_tags_seeded';
 

--- a/src/Rest/CorsHandler.php
+++ b/src/Rest/CorsHandler.php
@@ -178,52 +178,27 @@ class CorsHandler {
 	 * @return void
 	 */
 	public function register(): void {
-		add_action( 'rest_api_init', [ $this, 'send_cors_headers' ], 5 );
-		add_filter( 'rest_pre_serve_request', [ $this, 'handle_preflight' ], 10, 4 );
+		// Priority 100 puts us after WP core's rest_send_cors_headers
+		// (priority 10) AND after WP_REST_Server::send_header() emissions
+		// for Access-Control-Allow-Headers / -Expose-Headers (which fire
+		// inside serve_request before this filter runs). We need to be
+		// the last writer or core's empty Allow-Origin (sanitize_url
+		// strips chrome-extension://, which is not in wp_allowed_protocols)
+		// is what the browser sees.
+		add_filter( 'rest_pre_serve_request', [ $this, 'send_cors_response' ], 100, 4 );
 	}
 
 	/**
-	 * Sends CORS headers when the request origin is allow-listed and short-circuits
-	 * WP core's own CORS handler for the LinkStash namespace.
+	 * Emits the LinkStash CORS response headers and, for OPTIONS preflight,
+	 * short-circuits the request with a 204.
 	 *
-	 * WP core's `rest_send_cors_headers` runs `sanitize_url()` on the Origin
-	 * header, which drops `chrome-extension://...` because that scheme is
-	 * not in `wp_allowed_protocols()`. The result is an empty
-	 * `Access-Control-Allow-Origin:` value, which browsers reject — so the
-	 * extension's preflight fails and the actual POST never runs. By
-	 * removing the core hook and emitting our own headers (only on
-	 * LinkStash routes, only when the origin matches the allow-list) we
-	 * stay the sole emitter and the response carries the right value.
-	 *
-	 * @return void
-	 */
-	public function send_cors_headers(): void {
-		if ( ! self::is_linkstash_route() ) {
-			return;
-		}
-
-		$origin = self::request_origin();
-		if ( $origin === '' || ! self::is_allowed_origin( $origin ) ) {
-			return;
-		}
-
-		// Drop WP core's CORS hook so it can't overwrite the headers we're
-		// about to emit. Removed on a per-request basis — we only reach this
-		// line when the request is on a LinkStash route with an allow-listed
-		// origin, so other namespaces / origins still go through core.
-		remove_filter( 'rest_pre_serve_request', 'rest_send_cors_headers' );
-
-		\header( 'Access-Control-Allow-Origin: ' . $origin );
-		\header( 'Access-Control-Allow-Methods: ' . self::ALLOWED_METHODS );
-		\header( 'Access-Control-Allow-Headers: ' . self::ALLOWED_HEADERS );
-		\header( 'Access-Control-Allow-Credentials: true' );
-		\header( 'Access-Control-Expose-Headers: ' . self::EXPOSED_HEADERS );
-		\header( 'Vary: Origin' );
-	}
-
-	/**
-	 * Handles `OPTIONS` preflight for the LinkStash namespace by short-circuiting
-	 * with CORS response headers before authentication runs.
+	 * Runs late on `rest_pre_serve_request` (priority 100) to be the last
+	 * writer for the CORS header set. This means our values overwrite WP
+	 * core's `rest_send_cors_headers` (which would otherwise emit an empty
+	 * `Access-Control-Allow-Origin` for `chrome-extension://...` because
+	 * `sanitize_url()` strips schemes outside `wp_allowed_protocols()`)
+	 * and `WP_REST_Server::send_header()` defaults for Allow-Headers and
+	 * Expose-Headers.
 	 *
 	 * @param bool  $served  Whether the request has already been served.
 	 * @param mixed $result  The REST response (unused).
@@ -232,14 +207,10 @@ class CorsHandler {
 	 *
 	 * @return bool
 	 */
-	public function handle_preflight( bool $served, mixed $result, mixed $request, mixed $server ): bool {
+	public function send_cors_response( bool $served, mixed $result, mixed $request, mixed $server ): bool {
 		unset( $result, $request, $server );
 
-		if ( $served ) {
-			return $served;
-		}
-
-		if ( ! self::is_options_request() || ! self::is_linkstash_route() ) {
+		if ( ! self::is_linkstash_route() ) {
 			return $served;
 		}
 
@@ -251,11 +222,16 @@ class CorsHandler {
 		\header( 'Access-Control-Allow-Origin: ' . $origin );
 		\header( 'Access-Control-Allow-Methods: ' . self::ALLOWED_METHODS );
 		\header( 'Access-Control-Allow-Headers: ' . self::ALLOWED_HEADERS );
+		\header( 'Access-Control-Allow-Credentials: true' );
 		\header( 'Access-Control-Expose-Headers: ' . self::EXPOSED_HEADERS );
-		\header( 'Access-Control-Max-Age: 86400' );
 		\header( 'Vary: Origin' );
-		status_header( 204 );
 
-		return true;
+		if ( self::is_options_request() && ! $served ) {
+			\header( 'Access-Control-Max-Age: 86400' );
+			status_header( 204 );
+			return true;
+		}
+
+		return $served;
 	}
 }

--- a/src/Rest/CorsHandler.php
+++ b/src/Rest/CorsHandler.php
@@ -178,28 +178,45 @@ class CorsHandler {
 	 * @return void
 	 */
 	public function register(): void {
-		add_action( 'rest_api_init', [ $this, 'send_cors_headers' ], 15 );
+		add_action( 'rest_api_init', [ $this, 'send_cors_headers' ], 5 );
 		add_filter( 'rest_pre_serve_request', [ $this, 'handle_preflight' ], 10, 4 );
 	}
 
 	/**
-	 * Sends CORS headers when the request origin is allow-listed.
+	 * Sends CORS headers when the request origin is allow-listed and short-circuits
+	 * WP core's own CORS handler for the LinkStash namespace.
 	 *
-	 * Skipped when the request is not for the LinkStash namespace.
+	 * WP core's `rest_send_cors_headers` runs `sanitize_url()` on the Origin
+	 * header, which drops `chrome-extension://...` because that scheme is
+	 * not in `wp_allowed_protocols()`. The result is an empty
+	 * `Access-Control-Allow-Origin:` value, which browsers reject — so the
+	 * extension's preflight fails and the actual POST never runs. By
+	 * removing the core hook and emitting our own headers (only on
+	 * LinkStash routes, only when the origin matches the allow-list) we
+	 * stay the sole emitter and the response carries the right value.
 	 *
 	 * @return void
 	 */
 	public function send_cors_headers(): void {
+		if ( ! self::is_linkstash_route() ) {
+			return;
+		}
+
 		$origin = self::request_origin();
 		if ( $origin === '' || ! self::is_allowed_origin( $origin ) ) {
 			return;
 		}
 
-		if ( ! self::is_linkstash_route() ) {
-			return;
-		}
+		// Drop WP core's CORS hook so it can't overwrite the headers we're
+		// about to emit. Removed on a per-request basis — we only reach this
+		// line when the request is on a LinkStash route with an allow-listed
+		// origin, so other namespaces / origins still go through core.
+		remove_filter( 'rest_pre_serve_request', 'rest_send_cors_headers' );
 
 		\header( 'Access-Control-Allow-Origin: ' . $origin );
+		\header( 'Access-Control-Allow-Methods: ' . self::ALLOWED_METHODS );
+		\header( 'Access-Control-Allow-Headers: ' . self::ALLOWED_HEADERS );
+		\header( 'Access-Control-Allow-Credentials: true' );
 		\header( 'Access-Control-Expose-Headers: ' . self::EXPOSED_HEADERS );
 		\header( 'Vary: Origin' );
 	}

--- a/src/Rest/CorsHandler.php
+++ b/src/Rest/CorsHandler.php
@@ -178,13 +178,15 @@ class CorsHandler {
 	 * @return void
 	 */
 	public function register(): void {
-		// Priority 100 puts us after WP core's rest_send_cors_headers
-		// (priority 10) AND after WP_REST_Server::send_header() emissions
-		// for Access-Control-Allow-Headers / -Expose-Headers (which fire
-		// inside serve_request before this filter runs). We need to be
-		// the last writer or core's empty Allow-Origin (sanitize_url
-		// strips chrome-extension://, which is not in wp_allowed_protocols)
-		// is what the browser sees.
+		/*
+		 * Priority 100 puts us after WP core's rest_send_cors_headers
+		 * (priority 10) AND after WP_REST_Server::send_header() emissions
+		 * for Access-Control-Allow-Headers / -Expose-Headers (which fire
+		 * inside serve_request before this filter runs). We need to be
+		 * the last writer or core's empty Allow-Origin (sanitize_url
+		 * strips chrome-extension://, which is not in wp_allowed_protocols)
+		 * is what the browser sees.
+		 */
 		add_filter( 'rest_pre_serve_request', [ $this, 'send_cors_response' ], 100, 4 );
 	}
 

--- a/src/Rest/TagsController.php
+++ b/src/Rest/TagsController.php
@@ -72,13 +72,18 @@ class TagsController {
 				GROUP BY t.term_id, t.name, t.slug
 				ORDER BY t.name ASC";
 
-		// $sql is composed from `$wpdb->`-prefixed table names plus the
-		// `$where` fragment built in build_where_clause(), which contains
-		// only literal placeholders (`%s`/`%d`) and constant SQL — every
-		// user-controlled value flows through `$args` into wpdb::prepare.
-		// The remaining sniff (DirectQuery) is intentional: this single
-		// aggregate replaces an N+1 fan-out and is cached above.
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery
+		/*
+		 * $sql is composed from `$wpdb->`-prefixed table names plus the
+		 * `$where` fragment built in build_where_clause(), which contains
+		 * only literal placeholders (`%s`/`%d`) and constant SQL — every
+		 * user-controlled value flows through `$args` into wpdb::prepare.
+		 * The remaining sniff (DirectQuery) is intentional: this single
+		 * aggregate replaces an N+1 fan-out and is cached above. The
+		 * PluginCheck.Security.DirectDB.UnescapedDBParameter sniff fires
+		 * on the same false-positive (it doesn't follow the prepare()
+		 * call) and is suppressed alongside the WordPress.DB ones.
+		 */
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, PluginCheck.Security.DirectDB.UnescapedDBParameter
 		$rows = $wpdb->get_results( $wpdb->prepare( $sql, $args ), \ARRAY_A );
 		$rows = \is_array( $rows ) ? \array_values( $rows ) : [];
 

--- a/tests/Unit/Rest/CorsHandlerTest.php
+++ b/tests/Unit/Rest/CorsHandlerTest.php
@@ -87,6 +87,72 @@ class CorsHandlerTest extends TestCase {
 	}
 
 	/**
+	 * Verifies register hooks send_cors_headers early on rest_api_init.
+	 *
+	 * @return void
+	 */
+	public function test_register_hooks_rest_api_init_early(): void {
+		$handler = new CorsHandler();
+		$handler->register();
+
+		self::assertNotFalse( has_action( 'rest_api_init', [ $handler, 'send_cors_headers' ] ) );
+		self::assertNotFalse( has_filter( 'rest_pre_serve_request', [ $handler, 'handle_preflight' ] ) );
+	}
+
+	/**
+	 * Verifies send_cors_headers is a no-op when the request is not for
+	 * a LinkStash route, even if the origin would otherwise match.
+	 *
+	 * @return void
+	 */
+	public function test_send_cors_headers_skips_other_namespaces(): void {
+		$_SERVER['REQUEST_URI'] = '/wp-json/wp/v2/posts';
+		$_SERVER['HTTP_ORIGIN'] = 'chrome-extension://abc';
+		Functions\when( 'rest_get_url_prefix' )->justReturn( 'wp-json' );
+
+		Functions\expect( 'remove_filter' )->never();
+
+		( new CorsHandler() )->send_cors_headers();
+	}
+
+	/**
+	 * Verifies send_cors_headers removes WP core's CORS hook on LinkStash
+	 * routes when the origin is allow-listed — the empty-Origin bug fixed
+	 * in 0.1.3.
+	 *
+	 * @return void
+	 */
+	public function test_send_cors_headers_removes_core_hook_on_linkstash_route(): void {
+		$_SERVER['REQUEST_URI'] = '/wp-json/linkstash/v1/bookmarks';
+		$_SERVER['HTTP_ORIGIN'] = 'chrome-extension://abc';
+		Functions\when( 'rest_get_url_prefix' )->justReturn( 'wp-json' );
+		Filters\expectApplied( 'linkstash_allowed_origins' )->andReturn( [ 'chrome-extension://*' ] );
+
+		Functions\expect( 'remove_filter' )
+			->once()
+			->with( 'rest_pre_serve_request', 'rest_send_cors_headers' );
+
+		( new CorsHandler() )->send_cors_headers();
+	}
+
+	/**
+	 * Verifies send_cors_headers does not remove the core hook when the
+	 * origin is not allow-listed.
+	 *
+	 * @return void
+	 */
+	public function test_send_cors_headers_keeps_core_hook_for_unknown_origin(): void {
+		$_SERVER['REQUEST_URI'] = '/wp-json/linkstash/v1/bookmarks';
+		$_SERVER['HTTP_ORIGIN'] = 'https://attacker.tld';
+		Functions\when( 'rest_get_url_prefix' )->justReturn( 'wp-json' );
+		Filters\expectApplied( 'linkstash_allowed_origins' )->andReturn( [ 'chrome-extension://*' ] );
+
+		Functions\expect( 'remove_filter' )->never();
+
+		( new CorsHandler() )->send_cors_headers();
+	}
+
+	/**
 	 * Verifies handle_preflight returns early when the request is not OPTIONS.
 	 *
 	 * @return void

--- a/tests/Unit/Rest/CorsHandlerTest.php
+++ b/tests/Unit/Rest/CorsHandlerTest.php
@@ -87,104 +87,83 @@ class CorsHandlerTest extends TestCase {
 	}
 
 	/**
-	 * Verifies register hooks send_cors_headers early on rest_api_init.
+	 * Verifies register hooks send_cors_response on rest_pre_serve_request
+	 * at a high priority (so we run after core's CORS handler).
 	 *
 	 * @return void
 	 */
-	public function test_register_hooks_rest_api_init_early(): void {
+	public function test_register_hooks_rest_pre_serve_request_late(): void {
 		$handler = new CorsHandler();
 		$handler->register();
 
-		self::assertNotFalse( has_action( 'rest_api_init', [ $handler, 'send_cors_headers' ] ) );
-		self::assertNotFalse( has_filter( 'rest_pre_serve_request', [ $handler, 'handle_preflight' ] ) );
+		$priority = has_filter( 'rest_pre_serve_request', [ $handler, 'send_cors_response' ] );
+		self::assertNotFalse( $priority );
+		self::assertGreaterThan( 10, $priority, 'Must run after WP core rest_send_cors_headers (priority 10).' );
 	}
 
 	/**
-	 * Verifies send_cors_headers is a no-op when the request is not for
-	 * a LinkStash route, even if the origin would otherwise match.
+	 * Verifies send_cors_response is a no-op when the request is not for
+	 * a LinkStash route, returning the unchanged $served value.
 	 *
 	 * @return void
 	 */
-	public function test_send_cors_headers_skips_other_namespaces(): void {
-		$_SERVER['REQUEST_URI'] = '/wp-json/wp/v2/posts';
-		$_SERVER['HTTP_ORIGIN'] = 'chrome-extension://abc';
-		Functions\when( 'rest_get_url_prefix' )->justReturn( 'wp-json' );
-
-		Functions\expect( 'remove_filter' )->never();
-
-		( new CorsHandler() )->send_cors_headers();
-	}
-
-	/**
-	 * Verifies send_cors_headers removes WP core's CORS hook on LinkStash
-	 * routes when the origin is allow-listed — the empty-Origin bug fixed
-	 * in 0.1.3.
-	 *
-	 * @return void
-	 */
-	public function test_send_cors_headers_removes_core_hook_on_linkstash_route(): void {
-		$_SERVER['REQUEST_URI'] = '/wp-json/linkstash/v1/bookmarks';
-		$_SERVER['HTTP_ORIGIN'] = 'chrome-extension://abc';
-		Functions\when( 'rest_get_url_prefix' )->justReturn( 'wp-json' );
-		Filters\expectApplied( 'linkstash_allowed_origins' )->andReturn( [ 'chrome-extension://*' ] );
-
-		Functions\expect( 'remove_filter' )
-			->once()
-			->with( 'rest_pre_serve_request', 'rest_send_cors_headers' );
-
-		( new CorsHandler() )->send_cors_headers();
-	}
-
-	/**
-	 * Verifies send_cors_headers does not remove the core hook when the
-	 * origin is not allow-listed.
-	 *
-	 * @return void
-	 */
-	public function test_send_cors_headers_keeps_core_hook_for_unknown_origin(): void {
-		$_SERVER['REQUEST_URI'] = '/wp-json/linkstash/v1/bookmarks';
-		$_SERVER['HTTP_ORIGIN'] = 'https://attacker.tld';
-		Functions\when( 'rest_get_url_prefix' )->justReturn( 'wp-json' );
-		Filters\expectApplied( 'linkstash_allowed_origins' )->andReturn( [ 'chrome-extension://*' ] );
-
-		Functions\expect( 'remove_filter' )->never();
-
-		( new CorsHandler() )->send_cors_headers();
-	}
-
-	/**
-	 * Verifies handle_preflight returns early when the request is not OPTIONS.
-	 *
-	 * @return void
-	 */
-	public function test_preflight_skipped_for_non_options_request(): void {
-		$_SERVER['REQUEST_METHOD'] = 'GET';
-		$_SERVER['REQUEST_URI']    = '/wp-json/linkstash/v1/bookmarks';
+	public function test_send_cors_response_skips_other_namespaces(): void {
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_SERVER['REQUEST_URI']    = '/wp-json/wp/v2/posts';
 		$_SERVER['HTTP_ORIGIN']    = 'chrome-extension://abc';
-
 		Functions\when( 'rest_get_url_prefix' )->justReturn( 'wp-json' );
-		Filters\expectApplied( 'linkstash_allowed_origins' )->andReturn( [ 'chrome-extension://*' ] );
 
-		$handler = new CorsHandler();
-
-		self::assertFalse( $handler->handle_preflight( false, null, null, null ) );
+		$result = ( new CorsHandler() )->send_cors_response( false, null, null, null );
+		self::assertFalse( $result );
 	}
 
 	/**
-	 * Verifies an unknown origin is rejected during preflight.
+	 * Verifies send_cors_response is a no-op when the origin is not on the allow-list.
 	 *
 	 * @return void
 	 */
-	public function test_preflight_rejects_unknown_origin(): void {
-		$_SERVER['REQUEST_METHOD'] = 'OPTIONS';
+	public function test_send_cors_response_skips_unknown_origin(): void {
+		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$_SERVER['REQUEST_URI']    = '/wp-json/linkstash/v1/bookmarks';
 		$_SERVER['HTTP_ORIGIN']    = 'https://attacker.tld';
-
 		Functions\when( 'rest_get_url_prefix' )->justReturn( 'wp-json' );
 		Filters\expectApplied( 'linkstash_allowed_origins' )->andReturn( [ 'chrome-extension://*' ] );
 
-		$handler = new CorsHandler();
+		$result = ( new CorsHandler() )->send_cors_response( false, null, null, null );
+		self::assertFalse( $result );
+	}
 
-		self::assertFalse( $handler->handle_preflight( false, null, null, null ) );
+	/**
+	 * Verifies send_cors_response short-circuits an OPTIONS preflight with 204.
+	 *
+	 * @return void
+	 */
+	public function test_send_cors_response_serves_options_preflight(): void {
+		$_SERVER['REQUEST_METHOD'] = 'OPTIONS';
+		$_SERVER['REQUEST_URI']    = '/wp-json/linkstash/v1/bookmarks';
+		$_SERVER['HTTP_ORIGIN']    = 'chrome-extension://abc';
+		Functions\when( 'rest_get_url_prefix' )->justReturn( 'wp-json' );
+		Filters\expectApplied( 'linkstash_allowed_origins' )->andReturn( [ 'chrome-extension://*' ] );
+		Functions\when( 'status_header' )->justReturn( null );
+
+		$result = ( new CorsHandler() )->send_cors_response( false, null, null, null );
+		self::assertTrue( $result );
+	}
+
+	/**
+	 * Verifies send_cors_response on a non-OPTIONS LinkStash request returns
+	 * $served unchanged (we set headers but don't short-circuit the body).
+	 *
+	 * @return void
+	 */
+	public function test_send_cors_response_passes_through_post(): void {
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_SERVER['REQUEST_URI']    = '/wp-json/linkstash/v1/bookmarks';
+		$_SERVER['HTTP_ORIGIN']    = 'chrome-extension://abc';
+		Functions\when( 'rest_get_url_prefix' )->justReturn( 'wp-json' );
+		Filters\expectApplied( 'linkstash_allowed_origins' )->andReturn( [ 'chrome-extension://*' ] );
+
+		$result = ( new CorsHandler() )->send_cors_response( false, null, null, null );
+		self::assertFalse( $result );
 	}
 }


### PR DESCRIPTION
## Summary

**Hotfix.** v0.1.2 silently breaks the companion Chrome extension's save flow on most production hosts. Caught when the extension was configured against christoph-daum.de — "test connection" said OK (background service workers bypass CORS), but no bookmarks ever appeared in admin because every save POST was blocked by an empty `Access-Control-Allow-Origin:` header.

## Root cause

WP core's `rest_send_cors_headers` runs `sanitize_url()` on the incoming `Origin` header. `sanitize_url` honours `wp_allowed_protocols()`, which does not include `chrome-extension://` — so for any extension origin, core writes `Access-Control-Allow-Origin:` with an empty value. Browsers reject empty values per CORS spec → preflight fails → POST never runs.

Local DDEV happened to plug in the right hook order so our handler ran *after* core and overwrote the empty value. On the LiteSpeed/Apache stack on christoph-daum.de the order was reversed and core ran last, leaving the empty value as the final header.

Verified by direct curl against the prod endpoint:
- `OPTIONS /linkstash/v1/bookmarks` with `Origin: chrome-extension://...` → `access-control-allow-origin: ` (empty)
- `POST /linkstash/v1/bookmarks` with the same origin → same empty header
- Server-to-server `POST` (no Origin / no CORS) → `201 Created` (so the route works, only browser-side CORS is broken)

## Fix

`CorsHandler::send_cors_headers` now hooks `rest_api_init` at priority 5, and when the request is on a LinkStash route AND the origin is allow-listed, it:

1. Removes WP core's `rest_send_cors_headers` for this request only;
2. Emits the full CORS header set itself (`Access-Control-Allow-Origin`, `-Allow-Methods`, `-Allow-Headers`, `-Allow-Credentials`, `-Expose-Headers`, `Vary`).

Other namespaces and disallowed origins still flow through core untouched.

## Tests

- Three new tests in `CorsHandlerTest`:
  - Removes core hook on LinkStash route + allow-listed origin
  - Keeps core hook for non-LinkStash routes
  - Keeps core hook for unknown origins
- `test_register_hooks_rest_api_init_early` confirms the priority-5 wiring

178/274 tests/assertions, all green. PHPCS + PHPStan clean.

## Verification post-merge

Rebuild the wp.org submission ZIP from v0.1.3, install on christoph-daum.de, retry the extension save flow. Should land bookmarks. Then submit 0.1.3 (not 0.1.2) to wp.org.