### PR TITLE
Close /links and /tags REST reads + bump 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-10
+
 ### Changed
 
 - **Rename: LinkStash → Apermo Stash.** Slug `linkstash` →
@@ -33,6 +35,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Author URI on the plugin header is now
   `https://christoph-daum.com` (was `https://apermo.de`); the author
   is the person Christoph Daum, not the Apermo brand.
+
+### Security
+
+- **`GET /links` and `GET /tags` now require `edit_posts`.** Both
+  routes previously used `Permissions::allow_anyone` and were
+  reachable by unauthenticated callers; the wp.org Plugin Review
+  Team flagged this. Reads now require the same capability as
+  writes. The Chrome extension already authenticates via Bearer
+  token so its flow is unaffected, but any external caller that
+  relied on the routes being public will now see 403. The
+  `Permissions::allow_anyone` helper was removed since no
+  registration uses it any more — re-introducing public access in
+  the future should add a named callback rather than resurrecting
+  the generic always-true.
 
 ## [0.1.3] - 2026-05-03
 

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Apermo Stash
  * Plugin URI:  https://github.com/apermo/apermo-stash
  * Description: A self-hosted link collection with a token-protected REST API.
- * Version:     0.1.3
+ * Version:     0.2.0
  * Author:      Christoph Daum
  * Author URI:  https://christoph-daum.com
  * License:     GPL-2.0-or-later

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Apermo Stash ===
 Contributors: apermo
-Tags: links, links, rest-api, self-hosted, archive
+Tags: links, bookmarks, rest-api, self-hosted, archive
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.1
-Stable tag: 0.1.3
+Stable tag: 0.2.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -168,6 +168,17 @@ defense-in-depth narrowing of the CORS surface.
 5. Companion Chrome extension popup saving the current tab.
 
 == Changelog ==
+
+= 0.2.0 =
+* Renamed plugin: LinkStash → Apermo Stash. Slug, namespace,
+  text domain, REST namespace and Composer package all updated.
+* Renamed content type: bookmark → link. Post type slug
+  `apermo_stash_link`, REST endpoint `/links`, admin labels
+  "Link"/"Links". The 21-character `apermo_stash_bookmark` would
+  have exceeded WordPress's 20-char `register_post_type` limit.
+* Security: `GET /links` and `GET /tags` now require `edit_posts`
+  — both were previously reachable by unauthenticated callers.
+* Author URI changed from apermo.de to christoph-daum.com.
 
 = 0.1.3 =
 * Fixed: the Chrome extension's save flow now actually reaches the

--- a/src/Main.php
+++ b/src/Main.php
@@ -33,7 +33,7 @@ use Apermo\Stash\Url\MetadataFetcher;
  */
 class Main {
 
-	public const VERSION = '0.1.3';
+	public const VERSION = '0.2.0';
 
 	private const STARTER_TAGS_SEEDED_OPTION = 'apermo_stash_starter_tags_seeded';
 

--- a/src/Rest/LinksController.php
+++ b/src/Rest/LinksController.php
@@ -229,7 +229,7 @@ class LinksController {
 				[
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => [ $this, 'list_items' ],
-					'permission_callback' => [ Permissions::class, 'allow_anyone' ],
+					'permission_callback' => [ Permissions::class, 'require_read_links' ],
 					'args'                => self::list_args(),
 				],
 				[

--- a/src/Rest/Permissions.php
+++ b/src/Rest/Permissions.php
@@ -16,16 +16,6 @@ use WP_REST_Request;
 class Permissions {
 
 	/**
-	 * Allows the request through unconditionally; visibility is enforced at
-	 * the query level instead of denying access wholesale.
-	 *
-	 * @return bool
-	 */
-	public static function allow_anyone(): bool {
-		return true;
-	}
-
-	/**
 	 * Allows write requests when the resolved user can edit links.
 	 *
 	 * @return bool|WP_Error

--- a/src/Rest/TagsController.php
+++ b/src/Rest/TagsController.php
@@ -145,7 +145,7 @@ class TagsController {
 				[
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => [ $this, 'list_items' ],
-					'permission_callback' => [ Permissions::class, 'allow_anyone' ],
+					'permission_callback' => [ Permissions::class, 'require_read_links' ],
 				],
 			],
 		);

--- a/tests/Unit/Rest/LinksControllerTest.php
+++ b/tests/Unit/Rest/LinksControllerTest.php
@@ -6,6 +6,7 @@ namespace Apermo\Stash\Tests\Unit\Rest;
 
 use Apermo\Stash\PostType\LinkPostType;
 use Apermo\Stash\Rest\LinksController;
+use Apermo\Stash\Rest\Permissions;
 use Apermo\Stash\Url\MetadataFetcher;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
@@ -69,6 +70,31 @@ class LinksControllerTest extends TestCase {
 		Functions\expect( 'register_rest_route' )->twice();
 
 		$this->controller()->register_routes( 'apermo-stash/v1' );
+	}
+
+	/**
+	 * Verifies the GET /links collection route requires read_links —
+	 * anonymous callers no longer have unauthenticated access to the
+	 * link library.
+	 *
+	 * @return void
+	 */
+	public function test_collection_get_requires_read_links(): void {
+		$captured = [];
+		Functions\when( 'register_rest_route' )->alias(
+			static function ( string $rest_namespace, string $route, array $args ) use ( &$captured ): bool {
+				$captured[ $route ] = $args;
+				return true;
+			},
+		);
+
+		$this->controller()->register_routes( 'apermo-stash/v1' );
+
+		self::assertArrayHasKey( '/links', $captured );
+		self::assertSame(
+			[ Permissions::class, 'require_read_links' ],
+			$captured['/links'][0]['permission_callback'],
+		);
 	}
 
 	/**

--- a/tests/Unit/Rest/PermissionsTest.php
+++ b/tests/Unit/Rest/PermissionsTest.php
@@ -41,15 +41,6 @@ class PermissionsTest extends TestCase {
 	}
 
 	/**
-	 * Verifies allow_anyone is unconditional.
-	 *
-	 * @return void
-	 */
-	public function test_allow_anyone(): void {
-		self::assertTrue( Permissions::allow_anyone() );
-	}
-
-	/**
 	 * Verifies require_edit_posts returns an error for users without the cap.
 	 *
 	 * @return void

--- a/tests/Unit/Rest/TagsControllerTest.php
+++ b/tests/Unit/Rest/TagsControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Apermo\Stash\Tests\Unit\Rest;
 
+use Apermo\Stash\Rest\Permissions;
 use Apermo\Stash\Rest\TagsController;
 use Apermo\Stash\Tests\Unit\Rest\Fixtures\WpdbMockForTags;
 use Brain\Monkey;
@@ -71,7 +72,8 @@ class TagsControllerTest extends TestCase {
 	}
 
 	/**
-	 * Verifies register_routes registers the /tags route.
+	 * Verifies register_routes registers the /tags route with the
+	 * `require_read_links` permission_callback (anonymous callers blocked).
 	 *
 	 * @return void
 	 */
@@ -79,7 +81,12 @@ class TagsControllerTest extends TestCase {
 		Functions\expect( 'register_rest_route' )
 			->once()
 			->withArgs(
-				static fn ( string $rest_namespace, string $route ): bool => $rest_namespace === 'apermo-stash/v1' && $route === '/tags',
+				static function ( string $rest_namespace, string $route, array $args ): bool {
+					return $rest_namespace === 'apermo-stash/v1'
+						&& $route === '/tags'
+						&& $args[0]['permission_callback']
+							=== [ Permissions::class, 'require_read_links' ];
+				},
 			);
 
 		( new TagsController() )->register_routes( 'apermo-stash/v1' );


### PR DESCRIPTION
## Summary

Closes #44.

`GET /wp-json/apermo-stash/v1/links` and `GET /wp-json/apermo-stash/v1/tags` previously used `Permissions::allow_anyone` and were reachable without authentication. The wp.org Plugin Review Team flagged this. The deliberate decision is to make all reads require the same `edit_posts` capability as writes — public access isn't an MVP requirement, and re-introducing it later behind a named callback is cleaner than starting permissive.

Also bumps the plugin to **0.2.0** and converts the in-flight CHANGELOG `[Unreleased]` block (rename + bookmark→link content-type rename + this REST close) to `## [0.2.0] - 2026-05-10`.

## Changes

### REST close (commit `a49c640`)

- `src/Rest/LinksController.php` — `GET /links` `permission_callback`: `allow_anyone` → `require_read_links`.
- `src/Rest/TagsController.php` — `GET /tags` `permission_callback`: `allow_anyone` → `require_read_links`.
- `src/Rest/Permissions.php` — removed the `allow_anyone` helper since no registration uses it any more. A future public route should add a named callback rather than resurrect a generic always-true.
- Tests:
  - `PermissionsTest`: dropped `test_allow_anyone`.
  - `TagsControllerTest`: existing register-routes test now also asserts the `require_read_links` `permission_callback`.
  - `LinksControllerTest`: new `test_collection_get_requires_read_links` covers the same for `/links`.
- Visibility-layer query tests in `PermissionsAndVisibilityTest` are kept as-is — `build_where_clause` still handles the `(anonymous, authed, admin)` matrix in defense in depth, and the suite keeps the path covered against a future re-introduction of public reads.

### Version bump (commit `0b4807c`)

- `plugin.php` `Version: 0.2.0`
- `src/Main.php` `Main::VERSION = '0.2.0'`
- `readme.txt` `Stable tag: 0.2.0` + new `= 0.2.0 =` Changelog block
- `CHANGELOG.md` `## [Unreleased]` content moved under `## [0.2.0] - 2026-05-10`, with a new `### Security` bullet for this REST close
- Drive-by fix: `readme.txt` Tags line had a duplicate `links, links` from the bulk `bookmark → link` sweep — restored to `links, bookmarks, rest-api, self-hosted, archive`.

## Test plan

- [ ] CI green (PHPCS + PHPStan + PHPUnit on PHP 8.1–8.4 + integration matrix + e2e)
- [ ] Manual: anonymous `curl https://apermo-stash.ddev.site/wp-json/apermo-stash/v1/links` returns **403** (was 200)
- [ ] Manual: anonymous `curl https://apermo-stash.ddev.site/wp-json/apermo-stash/v1/tags` returns **403** (was 200)
- [ ] Manual: authenticated Bearer-token `curl` against both still returns 200 (Chrome extension flow check)
- [ ] CORS preflight (`OPTIONS`) still completes for both routes — the route's `permission_callback` is bypassed for preflight by core's CORS handler

## Out of scope

- The Chrome extension repo (`apermo/linkstash-extension`) was already authenticating via Bearer token before this change, so no coordinated update needed for the auth flow itself. The `/bookmarks` → `/links` endpoint rename in the prior rename PR is the breaking change there; that's tracked outside this PR.
- Re-introducing public-read access later: deliberately deferred. If/when needed, add a named callback (e.g. `allow_public_share`) rather than reviving `allow_anyone`.