### PR TITLE
chore: sync template apermo/template-wordpress to 0.10.2

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,25 @@
+# Mirrors apermo/reusable-workflows reusable-conventional-commits.yml.
+# Keep ALLOWED and MAX in lock-step with that workflow's defaults
+# (also referenced from .github/workflows/pr-validation.yml).
+
+ALLOWED='feat|fix|docs|style|refactor|test|chore|perf|ci|build'
+MAX=72
+MSG=$(head -n1 "$1")
+
+# Skip messages git itself generates.
+case "$MSG" in
+    Merge*|Revert\ \"*) exit 0 ;;
+esac
+
+if ! printf '%s\n' "$MSG" | grep -qE "^(${ALLOWED})(\(.+\))?!?: .{1,}$"; then
+    echo "✘ Commit subject must match: <type>[(scope)][!]: <description>" >&2
+    echo "  Allowed types: ${ALLOWED}" >&2
+    echo "  Got: $MSG" >&2
+    exit 1
+fi
+
+if [ ${#MSG} -gt $MAX ]; then
+    echo "✘ Commit subject is ${#MSG} chars, max ${MAX}." >&2
+    echo "  Got: $MSG" >&2
+    exit 1
+fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-05-25
+
+### Added
+
+- Local `.husky/commit-msg` hook validating the conventional-commit
+  prefix and 72-character subject length. Mirrors the rules
+  `pr-validation` already enforces in CI, so invalid commits now
+  fail at `git commit` time instead of only after `git push`.
+  Activates automatically on the next `npm install` via the
+  existing `prepare` script. Synced from template
+  [`apermo/template-wordpress` #43](https://github.com/apermo/template-wordpress/pull/43).
+
+### Fixed
+
+- "Please run `composer install`" admin notice no longer
+  false-positives when the plugin runs inside a Composer-managed
+  parent project (Bedrock and similar) that supplies the autoloader
+  itself. `plugin.php` now loads the local `vendor/autoload.php`
+  if present and only shows the notice when `Main` is still not
+  reachable. Synced from template
+  [`apermo/template-wordpress` #46](https://github.com/apermo/template-wordpress/pull/46).
+
+### Changed
+
+- `readme.txt` "Tested up to" bumped from 6.9 to 7.0 so Plugin
+  Check stops flagging `outdated_tested_upto_header`.
+
 ## [0.2.0] - 2026-05-10
 
 ### Changed

--- a/plugin.php
+++ b/plugin.php
@@ -18,7 +18,13 @@ namespace Apermo\Stash;
 
 \defined( 'ABSPATH' ) || exit();
 
-if ( ! \file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+if ( \file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+	require_once __DIR__ . '/vendor/autoload.php';
+}
+
+// Reached when neither a local vendor/autoload.php nor a parent project's
+// autoloader (Bedrock and similar) has registered the plugin's PSR-4 namespace.
+if ( ! \class_exists( Main::class ) ) {
 	add_action(
 		'admin_notices',
 		// phpcs:ignore Universal.FunctionDeclarations.NoLongClosures.ExceedsMaximum
@@ -38,7 +44,5 @@ if ( ! \file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	);
 	return;
 }
-
-require_once __DIR__ . '/vendor/autoload.php';
 
 Main::init( __FILE__ );

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Apermo Stash
  * Plugin URI:  https://github.com/apermo/apermo-stash
  * Description: A self-hosted link collection with a token-protected REST API.
- * Version:     0.2.0
+ * Version:     0.2.1
  * Author:      Christoph Daum
  * Author URI:  https://christoph-daum.com
  * License:     GPL-2.0-or-later

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: apermo
 Tags: links, bookmarks, rest-api, self-hosted, archive
 Requires at least: 6.4
-Tested up to: 6.9
+Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 0.2.0
+Stable tag: 0.2.1
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -168,6 +168,17 @@ defense-in-depth narrowing of the CORS surface.
 5. Companion Chrome extension popup saving the current tab.
 
 == Changelog ==
+
+= 0.2.1 =
+* Added: local `.husky/commit-msg` hook mirroring the
+  conventional-commit rules already enforced by CI's
+  `pr-validation` workflow.
+* Fixed: "Please run composer install" admin notice no longer
+  false-positives when the plugin runs inside a Composer-managed
+  parent project (Bedrock and similar). `plugin.php` now loads
+  the local autoloader if present and only shows the notice when
+  `Main` is still unreachable.
+* Changed: "Tested up to" bumped from 6.9 to 7.0.
 
 = 0.2.0 =
 * Renamed plugin: LinkStash → Apermo Stash. Slug, namespace,

--- a/src/Main.php
+++ b/src/Main.php
@@ -33,7 +33,7 @@ use Apermo\Stash\Url\MetadataFetcher;
  */
 class Main {
 
-	public const VERSION = '0.2.0';
+	public const VERSION = '0.2.1';
 
 	private const STARTER_TAGS_SEEDED_OPTION = 'apermo_stash_starter_tags_seeded';
 


### PR DESCRIPTION
## Summary

Selective sync of the upstream template `apermo/template-wordpress` up to **0.10.2**. Applied the cumulative changes the project did not yet have, kept the project's own branding/code, and excluded template-only scaffolding it never adopted.

### Brought in

- **`plugin.php` — 0.10.2 bootstrap guard.** Loads the local `vendor/autoload.php` when present, then bails with the "Please run `composer install`" notice only if `Main` is still not resolvable. Parent Composer projects (Bedrock and similar) that supply the autoloader stop triggering the false-positive notice. Template [#46](https://github.com/apermo/template-wordpress/pull/46).
- **`.husky/commit-msg` — 0.10.0 hook.** Mirrors the conventional-commit + 72-char-subject rules already enforced by `pr-validation` in CI, so invalid commits fail at `git commit` time instead of only on push. Activates automatically on the next `npm install` via the existing `prepare` script. Template [#43](https://github.com/apermo/template-wordpress/pull/43).

### Already in place / unchanged

- `.lintstagedrc.js` PHPStan memory limit (template 0.10.1) was already at 1G.
- `composer.json` `analyse` script already at `--memory-limit=1G`.

### Excluded on purpose

- Theme-mode scaffolding (`style.css`, `functions.php`, `src/Theme.php`, `templates/`, `parts/`, `theme.json`, `.lighthouserc.js`, `lhci.yml`, `assets/css|js/.gitkeep`). This is a plugin-mode project; theme files were stripped at bootstrap and shouldn't be re-added by a sync.
- `setup.sh` — removed once it had done its job (per `CLAUDE.md`).
- `src/Admin/DeactivationFlow.php` + view + test (template 0.9.0 opt-in confirm-deactivate example). Project never opted in; out of scope for the 0.10.x sync.

### CHANGELOG

Not a 1:1 merge of the template's CHANGELOG. Added a single `[Unreleased] → Changed` entry describing this sync; the template's historical entries are not copied in.

## Test plan

- [x] `composer cs` clean
- [x] `composer analyse` clean
- [x] `composer test:unit` — 185 tests, 289 assertions, all green
- [x] `npm install` reinstalls hooks; `.husky/commit-msg` is executable
- [x] Pre-commit hook ran on the commit (PHPCS + PHPStan via lint-staged)
- [ ] CI matrix on this PR

Closes #49