### PR TITLE
ci: bump actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ jobs:
         outputs:
             wp-versions: ${{ steps.versions.outputs.wp-versions }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - id: versions
               run: |
                   min=""

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -17,7 +17,7 @@ jobs:
         if: github.repository != 'apermo/template-wordpress'
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - name: Set up PHP
               uses: shivammathur/setup-php@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump GitHub Actions off the deprecated Node 20 runtime: `actions/checkout`
+  v4→v5. GitHub forces JavaScript actions onto Node 24 starting 2026-06-16.
+
 ## [0.2.1] - 2026-05-25
 
 ### Added


### PR DESCRIPTION
## Background

GitHub forces JavaScript actions off the deprecated Node 20 runtime starting **2026-06-16**, with full removal on 2026-09-16.

## Changes

- `actions/checkout` v4→v5

Each target is the first major of that action on the Node 24 runtime. Documented under `## [Unreleased]` so it ships without forcing a release.

Closes #54