### PR TITLE
feat(i18n): self-translate via Traduttore Registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-06-21
+
 ### Added
 
 - Self-hosted translation delivery via the Traduttore Registry: the plugin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Self-hosted translation delivery via the Traduttore Registry: the plugin
+  registers itself against the GlotPress server at `translate.chrdm.de` on
+  `init`, so any install receives translations without a wp.org language
+  pack. PHP strings load just-in-time on WordPress 7.0+.
+- `composer make-pot` dev script that regenerates
+  `languages/apermo-stash.pot`. The generated catalog is a build artifact
+  and stays out of git.
+
 ## [0.2.1] - 2026-05-25
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "test:integration": "phpunit --testsuite Integration",
         "analyse": "phpstan analyse --memory-limit=1G",
         "cs": "phpcs",
-        "cs:fix": "phpcbf"
+        "cs:fix": "phpcbf",
+        "make-pot": "wp i18n make-pot . languages/apermo-stash.pot --domain=apermo-stash --exclude=vendor,tests,e2e,.ddev,node_modules"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         }
     ],
     "require": {
-        "php": ">=8.1"
+        "php": ">=8.1",
+        "wearerequired/traduttore-registry": "^2.1"
     },
     "require-dev": {
         "apermo/apermo-coding-standards": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,76 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fcca7f7711263db43699653c06e09271",
-    "packages": [],
+    "content-hash": "9d4ec9e847614cc49296bb3f6079a3d2",
+    "packages": [
+        {
+            "name": "wearerequired/traduttore-registry",
+            "version": "2.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wearerequired/traduttore-registry.git",
+                "reference": "0a267c7e12928a17360f6157d358cc2a169734a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wearerequired/traduttore-registry/zipball/0a267c7e12928a17360f6157d358cc2a169734a1",
+                "reference": "0a267c7e12928a17360f6157d358cc2a169734a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "phpunit/phpunit": "^7.5.13",
+                "wearerequired/coding-standards": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "inc/namespace.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "required",
+                    "email": "support@required.ch",
+                    "homepage": "https://required.com",
+                    "role": "Company"
+                },
+                {
+                    "name": "Dominik Schilling",
+                    "email": "dominik@required.ch",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Pascal Birchler",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Allows loading translation files from a custom GlotPress site running Traduttore",
+            "homepage": "https://github.com/wearerequired/traduttore-registry",
+            "keywords": [
+                "glotpress",
+                "translations",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/wearerequired/traduttore-registry/issues",
+                "source": "https://github.com/wearerequired/traduttore-registry/tree/2.1.3"
+            },
+            "time": "2020-09-12T11:59:14+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "antecedent/patchwork",

--- a/languages/.gitignore
+++ b/languages/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/plugin.php
+++ b/plugin.php
@@ -8,6 +8,7 @@
  * Author URI:  https://christoph-daum.com
  * License:     GPL-2.0-or-later
  * Text Domain: apermo-stash
+ * Domain Path: /languages
  * Requires at least: 6.4
  * Requires PHP: 8.1
  */

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Apermo Stash
  * Plugin URI:  https://github.com/apermo/apermo-stash
  * Description: A self-hosted link collection with a token-protected REST API.
- * Version:     0.2.1
+ * Version:     0.2.2
  * Author:      Christoph Daum
  * Author URI:  https://christoph-daum.com
  * License:     GPL-2.0-or-later

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: links, bookmarks, rest-api, self-hosted, archive
 Requires at least: 6.4
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 0.2.1
+Stable tag: 0.2.2
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -168,6 +168,12 @@ defense-in-depth narrowing of the CORS surface.
 5. Companion Chrome extension popup saving the current tab.
 
 == Changelog ==
+
+= 0.2.2 =
+* Added: self-hosted translation delivery via the Traduttore
+  Registry. The plugin registers against the GlotPress server at
+  translate.chrdm.de on `init`, so installs receive translations
+  without a wp.org language pack.
 
 = 0.2.1 =
 * Added: local `.husky/commit-msg` hook mirroring the

--- a/src/I18n.php
+++ b/src/I18n.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\Stash;
+
+\defined( 'ABSPATH' ) || exit();
+
+use function Required\Traduttore_Registry\add_project;
+
+/**
+ * Registers the plugin with the self-hosted Traduttore Registry so installs
+ * receive translations from the GlotPress server at translate.chrdm.de.
+ *
+ * PHP translations are loaded just-in-time by WordPress 7.0+, so no manual
+ * `load_plugin_textdomain()` call is needed; this class only points WordPress
+ * at the translation source.
+ */
+final class I18n {
+
+	/**
+	 * Project type as understood by Traduttore Registry.
+	 */
+	private const PROJECT_TYPE = 'plugin';
+
+	/**
+	 * GlotPress translations API endpoint for this project. The trailing slash
+	 * is significant; the bare `/api/translations/` path returns a 404.
+	 */
+	private const API_URL = 'https://translate.chrdm.de/glotpress/api/translations/apermo-stash/';
+
+	/**
+	 * Wires the registration on init.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_action( 'init', [ $this, 'add_project' ] );
+	}
+
+	/**
+	 * Registers the project with Traduttore Registry when the library is
+	 * present. Degrades to a no-op when the dependency is missing.
+	 *
+	 * @return void
+	 */
+	public function add_project(): void {
+		if ( \function_exists( 'Required\Traduttore_Registry\add_project' ) ) {
+			add_project(
+				self::PROJECT_TYPE,
+				'apermo-stash',
+				self::API_URL,
+			);
+		}
+	}
+}

--- a/src/Main.php
+++ b/src/Main.php
@@ -33,7 +33,7 @@ use Apermo\Stash\Url\MetadataFetcher;
  */
 class Main {
 
-	public const VERSION = '0.2.1';
+	public const VERSION = '0.2.2';
 
 	private const STARTER_TAGS_SEEDED_OPTION = 'apermo_stash_starter_tags_seeded';
 

--- a/src/Main.php
+++ b/src/Main.php
@@ -142,6 +142,7 @@ class Main {
 	 * @return void
 	 */
 	public static function boot(): void {
+		( new I18n() )->register();
 		( new LinkPostType() )->register();
 		( new TagTaxonomy() )->register();
 		( new LinkMeta() )->register();

--- a/tests/Unit/I18nTest.php
+++ b/tests/Unit/I18nTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\Stash\Tests\Unit;
+
+use Apermo\Stash\I18n;
+use Brain\Monkey;
+use Brain\Monkey\Actions;
+use Brain\Monkey\Functions;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the Traduttore Registry project registration.
+ *
+ * The library autoloads its `Required\Traduttore_Registry\add_project()`
+ * function eagerly (composer `files` autoload), so the function is always
+ * defined in the test process and cannot be redefined by Brain Monkey. These
+ * tests therefore drive the real `add_project()` and assert on the WordPress
+ * hooks it wires.
+ */
+final class I18nTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/**
+	 * Sets up Brain Monkey.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	/**
+	 * Tears down Brain Monkey.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Confirms register() hooks the project registration on init.
+	 *
+	 * @return void
+	 */
+	public function test_register_hooks_init(): void {
+		$i18n = new I18n();
+
+		Actions\expectAdded( 'init' )
+			->once()
+			->with( [ $i18n, 'add_project' ] );
+
+		$i18n->register();
+	}
+
+	/**
+	 * Confirms the registry library is bundled so the runtime guard resolves.
+	 *
+	 * @return void
+	 */
+	public function test_registry_library_is_available(): void {
+		$this->assertTrue(
+			\function_exists( 'Required\Traduttore_Registry\add_project' ),
+			'The Traduttore Registry library must ship with the plugin.',
+		);
+	}
+
+	/**
+	 * Confirms add_project() wires the registry's translation filters for the
+	 * apermo-stash slug.
+	 *
+	 * add_project() mutates the library's static project registry, so this runs
+	 * in a separate process to keep that state out of sibling tests.
+	 *
+	 * @return void
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_adds_project_when_library_present(): void {
+		$filters = [];
+		// has_action/add_action stubs satisfy the registry's own internal cron
+		// wiring; only the add_filter calls are the subject of this test.
+		Functions\when( 'has_action' )->justReturn( false );
+		Functions\when( 'add_action' )->justReturn( true );
+		Functions\when( 'add_filter' )->alias(
+			static function ( string $hook ) use ( &$filters ): bool {
+				$filters[] = $hook;
+
+				return true;
+			},
+		);
+
+		( new I18n() )->add_project();
+
+		$this->assertContains( 'translations_api', $filters );
+		$this->assertContains( 'site_transient_update_plugins', $filters );
+	}
+}


### PR DESCRIPTION
## Summary

Adds self-hosted i18n delivery for apermo-stash via the
[Traduttore Registry](https://github.com/wearerequired/traduttore-registry),
mirroring the pattern shipped in apermo-notify v0.1.3.

The plugin registers itself on `init` against the GlotPress server at
`translate.chrdm.de`, so any install receives translations without a
wp.org language pack. PHP strings load just-in-time on WordPress 7.0+.
There are no custom blocks, so no `wp_set_script_translations()` step is
needed.

## Changes

- `wearerequired/traduttore-registry` added as a production dependency
  (resolved to `^2.1`).
- New `Apermo\Stash\I18n` class wired into `Main::boot()`, guarded by a
  `function_exists()` check so a missing dependency degrades to a no-op.
- `Domain Path: /languages` plugin header.
- `composer make-pot` dev script regenerating `languages/apermo-stash.pot`;
  the generated catalog is a build artifact kept out of git via
  `languages/.gitignore`.
- Unit coverage for the registration hooks (`translations_api`,
  `site_transient_update_plugins`).

## Release prep

Patch bump `0.2.1` → `0.2.2` across `plugin.php`, `Main::VERSION`,
`readme.txt` (Stable tag + changelog), and `CHANGELOG.md`.

## Verification

- `composer cs` clean
- `composer analyse` clean
- `composer test:unit` green (188 tests, 293 assertions)
- `ddev composer make-pot` generates `languages/apermo-stash.pot`;
  `git status` confirms it stays gitignored.

Closes #56. Implements chrdm.de#102.
